### PR TITLE
Add a changeset for the data-od-viewer hook

### DIFF
--- a/.changeset/lucky-donkeys-shave.md
+++ b/.changeset/lucky-donkeys-shave.md
@@ -1,0 +1,5 @@
+---
+"@open-document/core": patch
+---
+
+Mark the viewer's scrolling pane with `data-od-viewer` so page frames in the main pane can be told apart from the thumbnail rail.


### PR DESCRIPTION
`data-od-viewer` shipped in `packages/core` with the e2e suite but never got a changeset, so it is sitting unreleased on `main`. This adds the patch entry.

It doubles as the first end-to-end exercise of the release pipeline: merging this should open a "chore: release packages" PR, and merging *that* should publish `@open-document/core@0.1.1` from CI over OIDC trusted publishing — the one link in the chain that has never actually run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)