### PR TITLE
Point changesets and the issue template at the org repo

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://unpkg.com/@changesets/config@3.1.4/schema.json",
-  "changelog": ["@changesets/changelog-github", { "repo": "LiuYuWei/open-doc" }],
+  "changelog": ["@changesets/changelog-github", { "repo": "simonliu-ai-product/open-doc" }],
   "commit": false,
   "fixed": [],
   "linked": [],

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Questions & discussion
-    url: https://github.com/LiuYuWei/open-doc/discussions
+    url: https://github.com/simonliu-ai-product/open-doc/discussions
     about: Ask a question or share the documents you're building with open-doc.


### PR DESCRIPTION
The move to `simonliu-ai-product` missed two files. ripgrep skips hidden directories unless `--hidden` is passed, so the substitution never reached `.changeset/` or `.github/`.

Consequences:
- `@changesets/changelog-github` could not resolve `LiuYuWei/open-doc`, so the Release run on `main` failed before it could open the release PR.
- The "Questions & discussion" link in the issue template pointed at a repo that does not exist.

🤖 Generated with [Claude Code](https://claude.com/claude-code)