### PR TITLE
Publish the reader's position for agents

### DIFF
--- a/.changeset/olive-moons-report.md
+++ b/.changeset/olive-moons-report.md
@@ -1,0 +1,5 @@
+---
+"@open-document/core": minor
+---
+
+Publish the reader's position to `node_modules/.open-doc/current.json` while `open-doc dev` runs, and ship a `current-doc` skill so an agent can resolve "this page" and "this element" without asking. The cursor carries the document id, the rendered page number, the source path, and whatever the inspector has selected; a selection clears when you move to another sheet.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Every page component renders into a true sheet: A4 (794 × 1123 px @96dpi), Lett
 
 ### 🤖 Agent-native authoring
 
-Two skills ship with the scaffolder:
+Skills ship with the scaffolder:
 
 - **`/create-doc`** — drafts a document end to end. Establishes topic, audience, and *source material* first (it will not invent your numbers), asks four scoping questions, plans the pages, then writes them.
 - **`/doc-authoring`** — the technical reference: file contract, page canvas, print type scale, the vertical budget that decides where pages break, tables, charts, assets.
+- **`/current-doc`** — resolves "this page" and "this element". The dev server publishes where you are reading to `node_modules/.open-doc/current.json`, so your agent edits the sheet you are looking at instead of asking which one you mean.
 
 ### 🔌 An MCP server, so any agent framework can drive it
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -31,10 +31,11 @@ npx @open-document/cli init my-docs
 
 ### 🤖 為 agent 設計的撰寫流程
 
-Scaffolder 內建兩個 skill：
+Scaffolder 內建這些 skill：
 
 - **`/create-doc`** — 從頭到尾起草一份文件。先確立主題、讀者與**素材來源**（它不會杜撰你的數字），問四個界定範圍的問題，規劃頁面，然後寫出來。
 - **`/doc-authoring`** — 技術參考：檔案契約、頁面畫布、列印字級、決定分頁位置的垂直預算、表格、圖表、素材。
+- **`/current-doc`** — 解析「這一頁」「這個元素」。Dev server 會把你正在讀的位置寫進 `node_modules/.open-doc/current.json`，agent 就會改你正在看的那張紙，而不是反問你指的是哪一頁。
 
 ### 🔌 MCP server，任何 agent framework 都能接
 

--- a/packages/cli/template/AGENTS.md
+++ b/packages/cli/template/AGENTS.md
@@ -14,6 +14,7 @@ You author **documents** here — reports, proposals, whitepapers, memos. Each d
 | --- | --- |
 | `create-doc` | Drafting a new document end to end — scoping questions, page plan, then the file. |
 | `doc-authoring` | The technical reference: file contract, page canvas, print type scale, vertical budget, tables, TOC, page numbers. Read before any edit under `docs/`. |
+| `current-doc` | Resolving "this page" / "this element" — reads the cursor the dev server writes to `node_modules/.open-doc/current.json`. |
 
 ## Commands
 

--- a/packages/core/e2e/tests/current.spec.ts
+++ b/packages/core/e2e/tests/current.spec.ts
@@ -1,0 +1,89 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import { expect, test } from '@playwright/test';
+import { devScratchDir, openDoc, viewer } from './helpers.ts';
+
+const CURRENT = path.join(devScratchDir, 'node_modules', '.open-doc', 'current.json');
+
+type Current = {
+  docId: string;
+  pageIndex: number;
+  pageNumber: number;
+  totalPages: number;
+  docTitle: string;
+  pagePath: string;
+  selection: { line: number; column: number; tagName: string; text: string } | null;
+  updatedAt: string;
+};
+
+async function readCurrent(): Promise<Current | null> {
+  try {
+    return JSON.parse(await fs.readFile(CURRENT, 'utf8')) as Current;
+  } catch {
+    return null;
+  }
+}
+
+test.describe('current.json cursor', () => {
+  test('opening a document publishes where the reader is', async ({ page }) => {
+    await openDoc(page, 'alpha');
+    await expect.poll(async () => (await readCurrent())?.docId, { timeout: 15_000 }).toBe('alpha');
+
+    const current = await readCurrent();
+    expect(current?.docTitle).toBe('Alpha Report');
+    expect(current?.pagePath).toBe('docs/alpha/index.tsx');
+    expect(current?.totalPages).toBe(3);
+    expect(current?.pageNumber).toBe(1);
+  });
+
+  test('navigating to another page moves the cursor', async ({ page }) => {
+    await openDoc(page, 'alpha');
+    await page.locator('[data-thumb-page="3"]').click();
+    await expect.poll(async () => (await readCurrent())?.pageNumber, { timeout: 15_000 }).toBe(3);
+    expect((await readCurrent())?.pageIndex).toBe(2);
+  });
+
+  test('a flow document reports its packed page count', async ({ page }) => {
+    await openDoc(page, 'flow-report');
+    await expect
+      .poll(async () => (await readCurrent())?.docId, { timeout: 15_000 })
+      .toBe('flow-report');
+    const current = await readCurrent();
+    const rendered = await viewer(page).locator('[data-od-page]').count();
+    expect(current?.totalPages).toBe(rendered);
+  });
+
+  test('picking an element in the inspector publishes the selection', async ({ page }) => {
+    await openDoc(page, 'edit-target');
+    await page.getByRole('button', { name: 'Inspect' }).click();
+    await viewer(page).getByText('Editable heading').click();
+
+    await expect
+      .poll(async () => (await readCurrent())?.selection?.text, { timeout: 15_000 })
+      .toBe('Editable heading');
+
+    const selection = (await readCurrent())?.selection;
+    expect(selection?.tagName).toBe('h1');
+    expect(selection?.line).toBeGreaterThan(0);
+
+    // The line it reports has to be the one an agent would open.
+    const source = await fs.readFile(
+      path.join(devScratchDir, 'docs/edit-target/index.tsx'),
+      'utf8',
+    );
+    expect(source.split('\n')[(selection?.line ?? 1) - 1]).toContain('Editable heading');
+  });
+
+  test('moving to another document clears a stale selection', async ({ page }) => {
+    await openDoc(page, 'edit-target');
+    await page.getByRole('button', { name: 'Inspect' }).click();
+    await viewer(page).getByText('Editable heading').click();
+    await expect
+      .poll(async () => (await readCurrent())?.selection?.text, { timeout: 15_000 })
+      .toBe('Editable heading');
+
+    await openDoc(page, 'alpha');
+    await expect.poll(async () => (await readCurrent())?.docId, { timeout: 15_000 }).toBe('alpha');
+    expect((await readCurrent())?.selection).toBeNull();
+  });
+});

--- a/packages/core/skills/current-doc/SKILL.md
+++ b/packages/core/skills/current-doc/SKILL.md
@@ -1,0 +1,120 @@
+---
+name: current-doc
+description: Resolve which document, page, and (optionally) selected element the user is currently viewing in the open-doc dev server. Consult this whenever the user references "this page", "this document", "this element", "the page I'm on", "the report I'm looking at", or any deictic reference to document content without naming it. Re-read `node_modules/.open-doc/current.json` at the start of every such turn — the user navigates between turns, so a value you read earlier in the conversation is almost certainly stale.
+---
+
+# Where is the user right now?
+
+When the user says "fix this page", "tighten this heading", or "the report I'm looking at", they almost never name the document id, page number, or element — they mean wherever they are in the dev viewer. Before asking "which document?" or "which element?", check the file the dev server writes on every navigation and inspector pick.
+
+## Re-read on every deictic turn — never reuse a prior read
+
+`current.json` is a live cursor, not a fact about the conversation. The user moves between documents, pages, and elements freely between your turns — including while you were doing other work. **Read the file fresh at the start of every new turn that uses a deictic reference**, even if:
+
+- you already read it earlier in this same conversation,
+- you just finished editing the document it pointed to,
+- the user's new message sounds like a continuation ("now make it bigger", "also fix this one", "keep going").
+
+A "continue editing" follow-up is exactly the case where the user has likely just scrolled to a different page or picked a different element. Trusting your last read here will silently edit the wrong sheet. Re-read, compare `docId` / `pageIndex` / `selection` against what you used last time, and act on the new values.
+
+## How to read it
+
+```
+node_modules/.open-doc/current.json
+```
+
+Path is relative to the project root (the user's `cwd`, the directory that contains `docs/` and `package.json`). Use the `Read` tool. The file is JSON.
+
+## What you get
+
+```json
+{
+  "docId": "q3-review",
+  "pageIndex": 2,
+  "pageNumber": 3,
+  "totalPages": 8,
+  "docTitle": "Q3 Review",
+  "pagePath": "docs/q3-review/index.tsx",
+  "selection": {
+    "line": 42,
+    "column": 6,
+    "tagName": "h2",
+    "text": "Availability"
+  },
+  "updatedAt": "2026-08-17T14:32:11.123Z"
+}
+```
+
+- `docId` — folder name under `docs/`. Use as-is for any `/__docs/<id>/...` API or as the URL segment (`/d/<docId>`).
+- `pageIndex` — 0-based **rendered** page index.
+- `pageNumber` — 1-based, for talking to the user ("page 3 of 8").
+- `totalPages` — how many sheets the document currently renders to.
+- `pagePath` — relative path to the document source. Hand straight to `Read` / `Edit`.
+- `selection` — `null` if nothing is selected. Otherwise, the JSX element the user picked in the inspector overlay:
+  - `line` (1-indexed) and `column` (0-indexed) point to the JSX opening tag inside `pagePath`. This is the canonical handle — match against the source line, not the rendered DOM.
+  - `tagName` is the rendered DOM tag, lowercased (`"h1"`, `"p"`, `"td"`).
+  - `text` is a trimmed snippet (≤120 chars) of the element's `textContent`, useful to confirm you are looking at the right node.
+  - Selection auto-clears whenever the user moves to a different document or page.
+- `updatedAt` — ISO timestamp of the last navigation or selection change. Use it to detect staleness.
+
+## Rendered pages are not entries in the default export
+
+This is the one thing that differs from a slide deck, and getting it wrong means editing the wrong thing.
+
+`export default [Cover, Contents, flow(<>…</>)]` has three *entries*, but may render to twelve *sheets* — the framework measures a `flow()` section and packs it across as many pages as it needs. So:
+
+- **`pageIndex` indexes rendered sheets, not the array.** Do not use it to subscript the default export.
+- To find what to edit, prefer `selection` (it points at real source coordinates), then the page's visible text, then the surrounding heading.
+- If the user is on a flow page and there is no selection, identify the content by what they can see — read the source and match the prose — rather than counting array entries.
+- A fixed `DocPage` component *is* one sheet, so for documents made only of fixed pages the index does line up. Confirm with `pagePath` before relying on that.
+
+## When to use this
+
+- The user references the current document/page deictically: "this", "here", "the page I'm on", "what I'm looking at".
+- The user references a specific element: "this heading", "this table", "tighten this", "make this smaller". If `selection` is non-null, that's the element they mean.
+- Before asking "which document?" or "which page?" as a clarifying question — check this file first.
+- Before guessing from `git log`, recently-edited files, or the newest folder under `docs/`.
+
+## When NOT to use this
+
+- The user names a document explicitly ("edit `q3-review`") — use that name directly.
+- The `apply-comments` workflow already finds its own targets via `@doc-comment` markers; it does not need this skill.
+- For listing or discovering documents — read `docs/` directly.
+
+## Staleness — verify before acting
+
+`updatedAt` is the last time the user navigated. Treat it like a cache:
+
+- **Fresh (under ~5 minutes old)**: trust it. Open `pagePath`, do the work.
+- **Older than ~5 minutes**: confirm with the user before editing. The dev server may not be running; the user may have switched contexts.
+- **Hours/days old**: ignore it. Ask which document they mean.
+
+A *newer* `updatedAt` than the one you saw last turn is the normal signal that the user has moved — switch to the new `docId` / `pageIndex` / `selection` without asking.
+
+## When the file is missing
+
+- The dev server has not been opened on a document yet, or has never run. A static build never writes it.
+- Don't create the file or guess. Ask which document they mean, or suggest they open it in the dev server first.
+
+## Example — page-level reference
+
+User: "tighten the spacing on this page"
+
+1. Read `node_modules/.open-doc/current.json`.
+2. Check `updatedAt` is recent.
+3. Read `pagePath` (e.g. `docs/q3-review/index.tsx`).
+4. Work out what is on `pageNumber` — by the selection, or by matching visible content, remembering that a flow section spans many sheets.
+5. Consult the `doc-authoring` skill for the spacing and vertical-budget rules, then edit in place.
+
+If `current.json` is missing or stale, ask: "Which document and page should I tighten? The dev server hasn't published a current page recently."
+
+## Example — element-level reference
+
+User: "make this bigger"
+
+1. Read `node_modules/.open-doc/current.json`.
+2. If `selection` is non-null, that is the element. Read `pagePath`, jump to `selection.line`, and find the JSX opening tag near that line/column. Confirm against `selection.text` and `tagName`.
+3. Consult `doc-authoring` for the print type scale before editing — a size that looks fine on screen can print below the legibility floor.
+4. Edit the JSX node in place.
+
+If `selection` is null, fall back to the page-level flow above — and consider asking "which element?", since the user used a deictic but hasn't picked one in the inspector.

--- a/packages/core/src/app/components/inspector/inspector.tsx
+++ b/packages/core/src/app/components/inspector/inspector.tsx
@@ -180,6 +180,22 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
     };
   }, [container, insidePanel, onExit, selected]);
 
+  // Report the pick to the dev server so `current.json` can answer "this
+  // element" for an agent. Clearing the selection clears it there too.
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    import.meta.hot.send('open-doc:current', {
+      selection: selected
+        ? {
+            line: selected.line,
+            column: selected.column,
+            tagName: selected.anchor.tagName.toLowerCase(),
+            text: normalize(selected.anchor.textContent ?? '').slice(0, 120),
+          }
+        : null,
+    });
+  }, [selected]);
+
   // Read the element's text from source, not from the DOM: only source can say
   // whether it is a single editable text child or markup we must not touch.
   useEffect(() => {

--- a/packages/core/src/app/routes/doc.tsx
+++ b/packages/core/src/app/routes/doc.tsx
@@ -230,6 +230,19 @@ export function Doc() {
     return () => document.removeEventListener('fullscreenchange', onChange);
   }, []);
 
+  // Tell the dev server where the reader is, so an agent can resolve "this
+  // page" from node_modules/.open-doc/current.json. See vite/current-plugin.ts.
+  useEffect(() => {
+    if (!import.meta.hot) return;
+    if (!docId || !doc || pages.length === 0) return;
+    import.meta.hot.send('open-doc:current', {
+      docId,
+      pageIndex: currentPage - 1,
+      totalPages: pages.length,
+      docTitle: doc.meta?.title ?? docId,
+    });
+  }, [docId, doc, currentPage, pages.length]);
+
   useEffect(() => {
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.metaKey || e.ctrlKey || e.altKey) return;

--- a/packages/core/src/vite/config.ts
+++ b/packages/core/src/vite/config.ts
@@ -5,6 +5,7 @@ import tailwindcss from '@tailwindcss/vite';
 import react from '@vitejs/plugin-react';
 import type { InlineConfig } from 'vite';
 import { apiPlugin } from './api-plugin.ts';
+import { currentPlugin } from './current-plugin.ts';
 import { designPlugin } from './design-plugin.ts';
 import { locTagsPlugin } from './loc-tags-plugin.ts';
 import { mcpPlugin } from './mcp-plugin.ts';
@@ -64,6 +65,7 @@ export async function createViteConfig(opts: CreateViteConfigOptions): Promise<I
       themesPlugin({ userCwd, config }),
       designPlugin({ userCwd, docsDir }),
       apiPlugin({ userCwd, docsDir, assetsDir, coreVersion: CORE_VERSION }),
+      currentPlugin({ userCwd, docsDir }),
       ...(opts.mcp ? [mcpPlugin({ userCwd, docsDir, assetsDir, coreVersion: CORE_VERSION })] : []),
     ],
     resolve: {

--- a/packages/core/src/vite/current-plugin.ts
+++ b/packages/core/src/vite/current-plugin.ts
@@ -1,0 +1,145 @@
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import type { Plugin, ViteDevServer } from 'vite';
+import { DOC_ID_RE } from './open-doc-plugin.ts';
+
+const TEXT_SNIPPET_MAX = 120;
+
+export type CurrentPluginOptions = {
+  userCwd: string;
+  docsDir?: string;
+};
+
+type IncomingPayload = {
+  docId?: unknown;
+  pageIndex?: unknown;
+  totalPages?: unknown;
+  docTitle?: unknown;
+  selection?: unknown;
+};
+
+type IncomingSelection = {
+  line?: unknown;
+  column?: unknown;
+  tagName?: unknown;
+  text?: unknown;
+};
+
+type Selection = {
+  line: number;
+  column: number;
+  tagName: string;
+  text: string;
+};
+
+type Cached = {
+  docId: string;
+  pageIndex: number;
+  pageNumber: number;
+  totalPages: number;
+  docTitle: string;
+  pagePath: string;
+  selection: Selection | null;
+};
+
+function parseSelection(raw: unknown): Selection | null {
+  if (raw == null || typeof raw !== 'object') return null;
+  const sel = raw as IncomingSelection;
+  if (typeof sel.line !== 'number' || !Number.isFinite(sel.line)) return null;
+  if (typeof sel.column !== 'number' || !Number.isFinite(sel.column)) return null;
+  const tagName =
+    typeof sel.tagName === 'string' ? sel.tagName.toLowerCase().slice(0, 32) : 'unknown';
+  const text =
+    typeof sel.text === 'string'
+      ? sel.text.replace(/\s+/g, ' ').trim().slice(0, TEXT_SNIPPET_MAX)
+      : '';
+  return {
+    line: Math.max(1, Math.floor(sel.line)),
+    column: Math.max(0, Math.floor(sel.column)),
+    tagName,
+    text,
+  };
+}
+
+/**
+ * Writes `node_modules/.open-doc/current.json` whenever the viewer navigates or
+ * the inspector picks an element, so an agent can resolve "this page" without
+ * asking. Dev only — a static build has no cursor to report.
+ */
+export function currentPlugin(opts: CurrentPluginOptions): Plugin {
+  const userCwd = opts.userCwd;
+  const docsDir = opts.docsDir ?? 'docs';
+  const outDir = path.join(userCwd, 'node_modules', '.open-doc');
+  const outFile = path.join(outDir, 'current.json');
+  const tmpFile = `${outFile}.tmp`;
+
+  let cached: Cached | null = null;
+
+  return {
+    name: 'open-doc:current',
+    apply: 'serve',
+    configureServer(server: ViteDevServer) {
+      server.ws.on('open-doc:current', async (raw: IncomingPayload) => {
+        const next: Cached = cached
+          ? { ...cached }
+          : {
+              docId: '',
+              pageIndex: 0,
+              pageNumber: 1,
+              totalPages: 1,
+              docTitle: '',
+              pagePath: '',
+              selection: null,
+            };
+
+        if (typeof raw?.docId === 'string') {
+          if (!DOC_ID_RE.test(raw.docId)) return;
+
+          const totalPages =
+            typeof raw.totalPages === 'number' &&
+            Number.isFinite(raw.totalPages) &&
+            raw.totalPages > 0
+              ? Math.floor(raw.totalPages)
+              : 1;
+          const rawIndex =
+            typeof raw.pageIndex === 'number' && Number.isFinite(raw.pageIndex)
+              ? Math.floor(raw.pageIndex)
+              : 0;
+          const pageIndex = Math.max(0, Math.min(totalPages - 1, rawIndex));
+          const docTitle = typeof raw.docTitle === 'string' ? raw.docTitle : raw.docId;
+          const pagePath = path.join(docsDir, raw.docId, 'index.tsx').split(path.sep).join('/');
+
+          // A move to another document or another sheet invalidates whatever the
+          // inspector had picked — reporting a stale element is worse than none.
+          if (cached?.docId !== raw.docId || cached?.pageIndex !== pageIndex) {
+            next.selection = null;
+          }
+
+          next.docId = raw.docId;
+          next.pageIndex = pageIndex;
+          next.pageNumber = pageIndex + 1;
+          next.totalPages = totalPages;
+          next.docTitle = docTitle;
+          next.pagePath = pagePath;
+        }
+
+        if ('selection' in raw) {
+          next.selection = parseSelection(raw.selection);
+        }
+
+        if (!next.docId) return;
+
+        cached = next;
+
+        const body = { ...next, updatedAt: new Date().toISOString() };
+        try {
+          await fs.mkdir(outDir, { recursive: true });
+          await fs.writeFile(tmpFile, `${JSON.stringify(body, null, 2)}\n`, 'utf8');
+          await fs.rename(tmpFile, outFile);
+        } catch {
+          // Best-effort: a transient FS error here shouldn't crash the dev server.
+        }
+      });
+    },
+  };
+}


### PR DESCRIPTION
Ports open-slide's `current-slide` cursor to open-doc.

**Runtime** — `vite/current-plugin.ts` (dev only) listens on the HMR socket and writes `node_modules/.open-doc/current.json` atomically on every navigation and inspector pick: `docId`, `pageIndex` / `pageNumber` / `totalPages`, `docTitle`, `pagePath`, and the selected element's source coordinates. A selection clears when the reader moves to another document or sheet, because reporting a stale element is worse than reporting none.

**Skill** — `packages/core/skills/current-doc/SKILL.md`, which syncs into the CLI template at build time. It carries one warning slide does not need: **`pageIndex` indexes rendered sheets, not entries in the default export** — a `flow()` section packs into many sheets, so subscripting the array with it edits the wrong thing.

**Tests** — 5 e2e cases: the cursor appears on open, follows page navigation, matches the packed page count on a flow document, reports a selection whose `line` really is the line an agent would open, and clears that selection on navigation. Suite is 62 green.

Field dropped vs open-slide: `view` (`slides` / `assets`) has no open-doc equivalent worth reporting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)