### PR TITLE
Add a changeset to republish the CLI

### DIFF
--- a/.changeset/tame-pianos-wave.md
+++ b/.changeset/tame-pianos-wave.md
@@ -1,0 +1,5 @@
+---
+"@open-document/cli": patch
+---
+
+Scaffold new workspaces against `@open-document/core` 0.2.0. The version range is stamped in at build time, so the previous release pinned new projects to `^0.1.0` — which under semver's 0.x rule excludes 0.2.0, leaving them without the `current-doc` cursor.


### PR DESCRIPTION
`@open-document/cli` stamps the core version range into the scaffolded project at build time (`__CORE_VERSION_AT_BUILD__`). The published 0.1.0 was built when core was 0.1.0, so `npx @open-document/cli init` writes `"@open-document/core": "^0.1.0"` — and under semver's 0.x rule that range excludes 0.2.0.

New projects therefore install a core without the `current-doc` cursor and still on vite 5. A patch release rebuilds the CLI against core 0.2.0 and fixes that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)