### PR TITLE
Correct the MCP tool count in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Skills ship with the scaffolder:
 
 ### 🔌 An MCP server, so any agent framework can drive it
 
-`open-doc dev --mcp` mounts an MCP endpoint next to the UI — 18 tools covering documents, surgical text edits, themes, assets, and folders. It is stateless Streamable HTTP, so a client just points at `http://localhost:5273/mcp` with no session handshake.
+`open-doc dev --mcp` mounts an MCP endpoint next to the UI — 19 tools covering documents, surgical text edits, themes, assets, and folders. It is stateless Streamable HTTP, so a client just points at `http://localhost:5273/mcp` with no session handshake.
 
 The tools and the browser share one implementation, so `write_document` / `write_text` take the content you last read and refuse a stale write with `409` rather than overwriting whoever got there first. See [packages/mcp](packages/mcp).
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -39,7 +39,7 @@ Scaffolder 內建這些 skill：
 
 ### 🔌 MCP server，任何 agent framework 都能接
 
-`open-doc dev --mcp` 會在 UI 旁邊掛上 MCP 端點——18 個工具，涵蓋文件、精準的文字編輯、themes、assets 與資料夾。它是無狀態的 Streamable HTTP，client 直接指向 `http://localhost:5273/mcp` 即可，不需要 session handshake。
+`open-doc dev --mcp` 會在 UI 旁邊掛上 MCP 端點——19 個工具，涵蓋文件、精準的文字編輯、themes、assets 與資料夾。它是無狀態的 Streamable HTTP，client 直接指向 `http://localhost:5273/mcp` 即可，不需要 session handshake。
 
 這些工具和瀏覽器共用同一份實作，所以 `write_document` / `write_text` 會接收你上次讀到的內容，遇到已被改動的檔案時回 `409` 拒絕寫入，而不是覆蓋掉先到的人。詳見 [packages/mcp](packages/mcp)。
 


### PR DESCRIPTION
`packages/mcp/src/tools.ts` has 19 `registerTool` calls; both READMEs said 18.

Counted against the source: 7 document tools, 3 text tools, 2 theme, 4 asset, 3 folder. The table in `packages/mcp/README.md` already covers all 19 — it just groups several per row — so only the root READMEs needed the number changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)