### PR TITLE
Add find, page jump, distinct zoom icons, and image export with a page range

### DIFF
--- a/.changeset/viewer-search-images-page-range.md
+++ b/.changeset/viewer-search-images-page-range.md
@@ -1,0 +1,16 @@
+---
+'@open-document/core': minor
+---
+
+Viewer: find in document, page jump, distinct zoom icons, and PNG/SVG export with a page range.
+
+- The toolbar had two identical square icons — fit-page and fullscreen. Fit-page is
+  now an up-down arrow, pairing with the left-right arrow that fits the width, and a
+  per-cent button resets the zoom to 100%.
+- The page counter is an input: type a number to jump there.
+- A find control beside it searches the rendered document. Matches are painted with
+  the CSS Custom Highlight API rather than wrapped in markup, so nothing React owns
+  is edited; a browser without the API still navigates between hits.
+- Download offers PNG and SVG alongside PDF and HTML, and asks which pages first —
+  all, the current one, or a range like `1-3, 5`. One page downloads as one file;
+  several arrive as a zip.

--- a/packages/core/e2e/tests/viewer.spec.ts
+++ b/packages/core/e2e/tests/viewer.spec.ts
@@ -12,7 +12,9 @@ test.describe('document viewer', () => {
   test('the header shows the title and the page counter', async ({ page }) => {
     await openDoc(page, 'alpha');
     await expect(page.getByRole('heading', { name: 'Alpha Report' })).toBeVisible();
-    await expect(page.locator('header').getByText(/^\d+ \/ 3$/)).toBeVisible();
+    /* The counter is a field you can type a page into, so it is read by its
+       accessible name and its value rather than as loose text. */
+    await expect(page.getByLabel('Page number, 3 pages')).toBeVisible();
   });
 
   test('the title sits at the centre of the header, not of the leftover space', async ({
@@ -54,7 +56,7 @@ test.describe('document viewer', () => {
   test('the thumbnail rail jumps to a page', async ({ page }) => {
     await openDoc(page, 'alpha');
     await page.locator('[data-thumb-page="3"]').click();
-    await expect(page.locator('header').getByText('3 / 3')).toBeVisible();
+    await expect(page.getByLabel('Page number, 3 pages')).toHaveValue('3');
   });
 
   test('the outline lists headings with their page numbers', async ({ page }) => {
@@ -65,7 +67,7 @@ test.describe('document viewer', () => {
     await expect(outline.getByText('Alpha page two')).toBeVisible();
 
     await outline.getByText('Alpha page three').click();
-    await expect(page.locator('header').getByText('3 / 3')).toBeVisible();
+    await expect(page.getByLabel('Page number, 3 pages')).toHaveValue('3');
   });
 
   test('the back link returns to the browser', async ({ page }) => {

--- a/packages/core/src/app/components/doc-search.tsx
+++ b/packages/core/src/app/components/doc-search.tsx
@@ -1,0 +1,248 @@
+/**
+ * Find text in the document.
+ *
+ * Matches are drawn with the CSS Custom Highlight API, which paints ranges held
+ * beside the DOM instead of wrapping anything in it. Wrapping would mean editing
+ * a tree React owns: the next render throws the marks away, or keeps them and
+ * loses the reader's place. Neither is recoverable from inside a highlighter.
+ *
+ * A browser without the API still gets working navigation — the view scrolls to
+ * each hit — it just cannot tint it. That is worth having; refusing to search at
+ * all because it cannot be coloured is not.
+ */
+
+import { ChevronDown, ChevronUp, Search, X } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+const ALL = 'od-search';
+const ACTIVE = 'od-search-active';
+
+type Hit = { range: Range; page: number };
+
+/* Case-insensitive, and accent-insensitive where the browser can be: a reader
+   searching for "resume" means the word, not the spelling with accents. Defined
+   outside the component so it is one function, not a new one every render —
+   which is also what stops it having to appear in a dependency list. */
+const fold = (value: string): string => value.normalize('NFKD').toLowerCase();
+
+const highlightsSupported = (): boolean =>
+  typeof CSS !== 'undefined' && 'highlights' in CSS && typeof Highlight !== 'undefined';
+
+function clearHighlights(): void {
+  if (!highlightsSupported()) return;
+  CSS.highlights.delete(ALL);
+  CSS.highlights.delete(ACTIVE);
+}
+
+/**
+ * Every text node under `root`, in document order.
+ *
+ * Script and style hold text that is not the document's text; matching inside
+ * them would send the reader to a hit they cannot see.
+ */
+function textNodes(root: HTMLElement): Text[] {
+  const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, {
+    acceptNode(node) {
+      const parent = node.parentElement;
+      if (!parent) return NodeFilter.FILTER_REJECT;
+      if (parent.closest('script,style,[data-od-search-skip]')) return NodeFilter.FILTER_REJECT;
+      return node.nodeValue?.trim() ? NodeFilter.FILTER_ACCEPT : NodeFilter.FILTER_REJECT;
+    },
+  });
+  const out: Text[] = [];
+  let node = walker.nextNode();
+  while (node) {
+    out.push(node as Text);
+    node = walker.nextNode();
+  }
+  return out;
+}
+
+function pageOf(node: Node, frames: Element[]): number {
+  const element = node.parentElement;
+  if (!element) return 0;
+  for (let i = 0; i < frames.length; i++) {
+    if (frames[i]?.contains(element)) return i + 1;
+  }
+  return 0;
+}
+
+export function DocSearch({
+  scrollRef,
+  pagesRef,
+  onFoundPage,
+}: {
+  scrollRef: React.RefObject<HTMLElement | null>;
+  pagesRef: React.RefObject<HTMLElement | null>;
+  onFoundPage?: (page: number) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState('');
+  const [hits, setHits] = useState<Hit[]>([]);
+  const [at, setAt] = useState(0);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const supported = useMemo(highlightsSupported, []);
+
+  const search = useCallback(
+    (text: string) => {
+      const root = pagesRef.current;
+      if (!root || text.trim() === '') {
+        clearHighlights();
+        setHits([]);
+        setAt(0);
+        return;
+      }
+
+      const needle = fold(text);
+      const frames = Array.from(root.children);
+      const found: Hit[] = [];
+
+      for (const node of textNodes(root)) {
+        const haystack = fold(node.nodeValue ?? '');
+        let from = haystack.indexOf(needle);
+        while (from !== -1) {
+          const range = document.createRange();
+          try {
+            range.setStart(node, from);
+            range.setEnd(node, from + needle.length);
+            found.push({ range, page: pageOf(node, frames) });
+          } catch {
+            /* Folding can change length, which puts the offset past the node.
+               Skipping that hit is better than throwing away the whole search. */
+          }
+          from = haystack.indexOf(needle, from + needle.length);
+        }
+      }
+
+      setHits(found);
+      setAt(found.length > 0 ? 1 : 0);
+    },
+    [pagesRef],
+  );
+
+  /* Painting is a side effect of the hits and the cursor, not of typing —
+     otherwise the active hit stays tinted after the reader moves off it. */
+  useEffect(() => {
+    if (!supported) return;
+    if (hits.length === 0) {
+      clearHighlights();
+      return;
+    }
+    const active = hits[at - 1];
+    CSS.highlights.set(ALL, new Highlight(...hits.map((hit) => hit.range)));
+    if (active) CSS.highlights.set(ACTIVE, new Highlight(active.range));
+    return clearHighlights;
+  }, [hits, at, supported]);
+
+  const go = useCallback(
+    (step: number) => {
+      if (hits.length === 0) return;
+      const next = ((at - 1 + step + hits.length) % hits.length) + 1;
+      setAt(next);
+      const hit = hits[next - 1];
+      if (!hit) return;
+      const target = hit.range.startContainer.parentElement;
+      const root = scrollRef.current;
+      if (target && root) {
+        const offset = target.getBoundingClientRect().top - root.getBoundingClientRect().top;
+        root.scrollTo({ top: root.scrollTop + offset - 120, behavior: 'smooth' });
+      }
+      if (hit.page > 0) onFoundPage?.(hit.page);
+    },
+    [at, hits, scrollRef, onFoundPage],
+  );
+
+  const close = useCallback(() => {
+    setOpen(false);
+    setQuery('');
+    clearHighlights();
+    setHits([]);
+    setAt(0);
+  }, []);
+
+  /* No ⌘F: that is the browser's own find, and taking it would replace a
+     control the reader already trusts with one that only searches this pane. */
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') close();
+    };
+    window.addEventListener('keydown', onKey);
+    return () => window.removeEventListener('keydown', onKey);
+  }, [open, close]);
+
+  useEffect(() => () => clearHighlights(), []);
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        aria-label="Find in document"
+        title="Find in document"
+        onClick={() => {
+          setOpen(true);
+          requestAnimationFrame(() => inputRef.current?.focus());
+        }}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <Search className="size-3.5" />
+      </button>
+    );
+  }
+
+  return (
+    <div className="flex items-center gap-1 rounded-md border border-border px-1.5 py-0.5 focus-within:border-foreground/40">
+      <Search className="size-3.5 flex-none text-muted-foreground" />
+      <input
+        ref={inputRef}
+        value={query}
+        onChange={(event) => {
+          setQuery(event.target.value);
+          search(event.target.value);
+        }}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            go(event.shiftKey ? -1 : 1);
+          }
+        }}
+        placeholder="Find"
+        aria-label="Find in document"
+        className="w-28 bg-transparent text-xs outline-none placeholder:text-muted-foreground"
+      />
+      <span className="flex-none font-mono text-[11px] text-muted-foreground tabular-nums">
+        {query === '' ? '' : hits.length === 0 ? '0' : `${at}/${hits.length}`}
+      </span>
+      <button
+        type="button"
+        aria-label="Previous match"
+        title="Previous match (⇧⏎)"
+        onClick={() => go(-1)}
+        disabled={hits.length === 0}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
+      >
+        <ChevronUp className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Next match"
+        title="Next match (⏎)"
+        onClick={() => go(1)}
+        disabled={hits.length === 0}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground disabled:opacity-40"
+      >
+        <ChevronDown className="size-3.5" />
+      </button>
+      <button
+        type="button"
+        aria-label="Close search"
+        title="Close search (Esc)"
+        onClick={close}
+        className="flex size-6 items-center justify-center rounded text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+      >
+        <X className="size-3.5" />
+      </button>
+    </div>
+  );
+}

--- a/packages/core/src/app/components/ui/menu.tsx
+++ b/packages/core/src/app/components/ui/menu.tsx
@@ -109,16 +109,19 @@ export function MenuItem({
   children,
   destructive = false,
   active = false,
+  disabled = false,
 }: {
   onClick: () => void;
   children: ReactNode;
   destructive?: boolean;
   active?: boolean;
+  disabled?: boolean;
 }) {
   return (
     <button
       type="button"
       role="menuitem"
+      disabled={disabled}
       onClick={(e) => {
         e.stopPropagation();
         onClick();
@@ -127,6 +130,7 @@ export function MenuItem({
         'flex w-full items-center gap-2 rounded px-2 py-1.5 text-left text-xs transition-colors hover:bg-accent',
         active && 'bg-accent',
         destructive && 'text-red-600 dark:text-red-400',
+        disabled && 'pointer-events-none opacity-40',
       )}
     >
       {children}

--- a/packages/core/src/app/lib/export-dom.ts
+++ b/packages/core/src/app/lib/export-dom.ts
@@ -1,0 +1,183 @@
+/**
+ * Shared by both exporters so there is one way to draw the document offscreen.
+ * Two copies would drift on font waiting, scanning, or design variables, and the
+ * difference would only ever show up in an exported file.
+ */
+
+import { createElement } from 'react';
+import { createRoot, type Root } from 'react-dom/client';
+import { designToCssVars } from './design';
+import { PAGE_ATTR, PAGE_INDEX_ATTR } from './outline';
+import { DocPageProvider } from './page-context';
+import { nextFrame, waitForFonts, waitForImages } from './print-ready';
+import { captureScan, restoreScan, scanDocument } from './scan';
+import type { DocModule, PageGeometry } from './sdk';
+import type { ExpandedPage } from './use-doc-pages';
+
+export const ASSET_EXT_RE =
+  /\.(?:png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf)(?:\?[^#]*)?(?:#.*)?$/i;
+
+export async function renderPagesToHtml(
+  pages: ExpandedPage[],
+  geometry: PageGeometry,
+  doc: DocModule,
+): Promise<string[]> {
+  const container = document.createElement('div');
+  container.setAttribute('aria-hidden', 'true');
+  Object.assign(container.style, {
+    position: 'fixed',
+    left: '-99999px',
+    top: '0',
+    pointerEvents: 'none',
+  });
+  document.body.appendChild(container);
+
+  const designVars = doc.design ? designToCssVars(doc.design) : null;
+  const roots: Root[] = [];
+  const hosts: HTMLElement[] = [];
+  const previousScan = captureScan();
+
+  try {
+    for (let i = 0; i < pages.length; i++) {
+      const page = pages[i];
+      if (!page) continue;
+      const host = document.createElement('div');
+      host.setAttribute(PAGE_ATTR, '');
+      host.setAttribute(PAGE_INDEX_ATTR, String(i));
+      host.style.width = `${geometry.width}px`;
+      host.style.height = `${geometry.height}px`;
+      if (designVars) {
+        for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
+      }
+      container.appendChild(host);
+      hosts.push(host);
+      const root = createRoot(host);
+      root.render(createElement(DocPageProvider, { index: i, total: pages.length }, page.content));
+      roots.push(root);
+    }
+
+    await nextFrame();
+    await waitForFonts();
+    await waitForImages(container);
+    scanDocument(container, doc.meta);
+    await nextFrame();
+    await nextFrame();
+
+    return hosts.map((host) => host.innerHTML);
+  } finally {
+    for (const root of roots) root.unmount();
+    container.remove();
+    restoreScan(previousScan);
+  }
+}
+export function collectCss(): string {
+  const chunks: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    let rules: CSSRuleList | null = null;
+    try {
+      rules = sheet.cssRules;
+    } catch {
+      continue;
+    }
+    if (!rules) continue;
+    for (const rule of Array.from(rules)) chunks.push(rule.cssText);
+  }
+  return chunks.join('\n');
+}
+export function collectExternalStylesheetLinks(): string {
+  const links: string[] = [];
+  for (const sheet of Array.from(document.styleSheets)) {
+    try {
+      void sheet.cssRules;
+    } catch {
+      if (sheet.href) links.push(`<link rel="stylesheet" href="${escapeAttr(sheet.href)}">`);
+    }
+  }
+  return links.join('\n');
+}
+export function findHtmlAssetUrls(html: string): string[] {
+  const out: string[] = [];
+  for (const m of html.matchAll(/\s(?:src|href)="([^"]+)"/g)) {
+    if (looksLikeAsset(m[1])) out.push(m[1]);
+  }
+  for (const m of html.matchAll(/\ssrcset="([^"]+)"/g)) {
+    for (const part of m[1].split(',')) {
+      const url = part.trim().split(/\s+/)[0];
+      if (url && looksLikeAsset(url)) out.push(url);
+    }
+  }
+  return out;
+}
+export function findCssAssetUrls(css: string): string[] {
+  const out: string[] = [];
+  for (const m of css.matchAll(/url\(\s*(['"]?)([^)'"]+)\1\s*\)/g)) {
+    const url = m[2].trim();
+    if (looksLikeAsset(url)) out.push(url);
+  }
+  return out;
+}
+export function looksLikeAsset(url: string): boolean {
+  if (!url) return false;
+  if (url.startsWith('data:') || url.startsWith('blob:') || url.startsWith('#')) return false;
+  if (url.startsWith('mailto:') || url.startsWith('javascript:')) return false;
+  const abs = toAbsolute(url);
+  if (!abs) return false;
+  try {
+    if (new URL(abs).origin !== window.location.origin) return false;
+  } catch {
+    return false;
+  }
+  return ASSET_EXT_RE.test(url);
+}
+export function toAbsolute(url: string): string | null {
+  try {
+    return new URL(url, window.location.href).toString();
+  } catch {
+    return null;
+  }
+}
+export function uniqueAssetName(absoluteUrl: string, used: Set<string>): string {
+  let base = 'asset';
+  try {
+    base = new URL(absoluteUrl).pathname.split('/').pop() || 'asset';
+  } catch {}
+  if (!used.has(base)) {
+    used.add(base);
+    return base;
+  }
+  const hash = shortHash(absoluteUrl);
+  const dot = base.lastIndexOf('.');
+  const name = dot > 0 ? `${base.slice(0, dot)}-${hash}${base.slice(dot)}` : `${base}-${hash}`;
+  used.add(name);
+  return name;
+}
+export function shortHash(input: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i++) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36).slice(0, 6);
+}
+export function downloadBlob(blob: Blob, filename: string): void {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = filename;
+  a.rel = 'noopener';
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  setTimeout(() => URL.revokeObjectURL(url), 0);
+}
+export function escapeHtml(s: string): string {
+  return s
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+export function escapeAttr(s: string): string {
+  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
+}

--- a/packages/core/src/app/lib/export-html.ts
+++ b/packages/core/src/app/lib/export-html.ts
@@ -1,16 +1,21 @@
-import { createElement } from 'react';
-import { createRoot, type Root } from 'react-dom/client';
 import { designToCssVars } from './design';
+import {
+  collectCss,
+  collectExternalStylesheetLinks,
+  downloadBlob,
+  escapeAttr,
+  escapeHtml,
+  findCssAssetUrls,
+  findHtmlAssetUrls,
+  renderPagesToHtml,
+  toAbsolute,
+  uniqueAssetName,
+} from './export-dom';
 import { PAGE_ATTR, PAGE_INDEX_ATTR } from './outline';
-import { DocPageProvider } from './page-context';
-import { nextFrame, waitForFonts, waitForImages } from './print-ready';
-import { captureScan, restoreScan, scanDocument } from './scan';
 import { type DocModule, type PageGeometry, resolvePageGeometry } from './sdk';
 import type { ExpandedPage } from './use-doc-pages';
 
 type AssetEntry = { name: string; bytes: Uint8Array };
-
-const ASSET_EXT_RE = /\.(?:png|jpe?g|gif|svg|webp|avif|woff2?|ttf|otf)(?:\?[^#]*)?(?:#.*)?$/i;
 
 export type HtmlBundle = {
   filename: string;
@@ -93,157 +98,6 @@ export async function exportDocAsHtml(
   downloadBlob(new Blob([bundle.bytes as BlobPart], { type: bundle.mimeType }), bundle.filename);
 }
 
-async function renderPagesToHtml(
-  pages: ExpandedPage[],
-  geometry: PageGeometry,
-  doc: DocModule,
-): Promise<string[]> {
-  const container = document.createElement('div');
-  container.setAttribute('aria-hidden', 'true');
-  Object.assign(container.style, {
-    position: 'fixed',
-    left: '-99999px',
-    top: '0',
-    pointerEvents: 'none',
-  });
-  document.body.appendChild(container);
-
-  const designVars = doc.design ? designToCssVars(doc.design) : null;
-  const roots: Root[] = [];
-  const hosts: HTMLElement[] = [];
-  const previousScan = captureScan();
-
-  try {
-    for (let i = 0; i < pages.length; i++) {
-      const page = pages[i];
-      if (!page) continue;
-      const host = document.createElement('div');
-      host.setAttribute(PAGE_ATTR, '');
-      host.setAttribute(PAGE_INDEX_ATTR, String(i));
-      host.style.width = `${geometry.width}px`;
-      host.style.height = `${geometry.height}px`;
-      if (designVars) {
-        for (const [k, v] of Object.entries(designVars)) host.style.setProperty(k, v);
-      }
-      container.appendChild(host);
-      hosts.push(host);
-      const root = createRoot(host);
-      root.render(createElement(DocPageProvider, { index: i, total: pages.length }, page.content));
-      roots.push(root);
-    }
-
-    await nextFrame();
-    await waitForFonts();
-    await waitForImages(container);
-    scanDocument(container, doc.meta);
-    await nextFrame();
-    await nextFrame();
-
-    return hosts.map((host) => host.innerHTML);
-  } finally {
-    for (const root of roots) root.unmount();
-    container.remove();
-    restoreScan(previousScan);
-  }
-}
-
-function collectCss(): string {
-  const chunks: string[] = [];
-  for (const sheet of Array.from(document.styleSheets)) {
-    let rules: CSSRuleList | null = null;
-    try {
-      rules = sheet.cssRules;
-    } catch {
-      continue;
-    }
-    if (!rules) continue;
-    for (const rule of Array.from(rules)) chunks.push(rule.cssText);
-  }
-  return chunks.join('\n');
-}
-
-function collectExternalStylesheetLinks(): string {
-  const links: string[] = [];
-  for (const sheet of Array.from(document.styleSheets)) {
-    try {
-      void sheet.cssRules;
-    } catch {
-      if (sheet.href) links.push(`<link rel="stylesheet" href="${escapeAttr(sheet.href)}">`);
-    }
-  }
-  return links.join('\n');
-}
-
-function findHtmlAssetUrls(html: string): string[] {
-  const out: string[] = [];
-  for (const m of html.matchAll(/\s(?:src|href)="([^"]+)"/g)) {
-    if (looksLikeAsset(m[1])) out.push(m[1]);
-  }
-  for (const m of html.matchAll(/\ssrcset="([^"]+)"/g)) {
-    for (const part of m[1].split(',')) {
-      const url = part.trim().split(/\s+/)[0];
-      if (url && looksLikeAsset(url)) out.push(url);
-    }
-  }
-  return out;
-}
-
-function findCssAssetUrls(css: string): string[] {
-  const out: string[] = [];
-  for (const m of css.matchAll(/url\(\s*(['"]?)([^)'"]+)\1\s*\)/g)) {
-    const url = m[2].trim();
-    if (looksLikeAsset(url)) out.push(url);
-  }
-  return out;
-}
-
-function looksLikeAsset(url: string): boolean {
-  if (!url) return false;
-  if (url.startsWith('data:') || url.startsWith('blob:') || url.startsWith('#')) return false;
-  if (url.startsWith('mailto:') || url.startsWith('javascript:')) return false;
-  const abs = toAbsolute(url);
-  if (!abs) return false;
-  try {
-    if (new URL(abs).origin !== window.location.origin) return false;
-  } catch {
-    return false;
-  }
-  return ASSET_EXT_RE.test(url);
-}
-
-function toAbsolute(url: string): string | null {
-  try {
-    return new URL(url, window.location.href).toString();
-  } catch {
-    return null;
-  }
-}
-
-function uniqueAssetName(absoluteUrl: string, used: Set<string>): string {
-  let base = 'asset';
-  try {
-    base = new URL(absoluteUrl).pathname.split('/').pop() || 'asset';
-  } catch {}
-  if (!used.has(base)) {
-    used.add(base);
-    return base;
-  }
-  const hash = shortHash(absoluteUrl);
-  const dot = base.lastIndexOf('.');
-  const name = dot > 0 ? `${base.slice(0, dot)}-${hash}${base.slice(dot)}` : `${base}-${hash}`;
-  used.add(name);
-  return name;
-}
-
-function shortHash(input: string): string {
-  let h = 2166136261;
-  for (let i = 0; i < input.length; i++) {
-    h ^= input.charCodeAt(i);
-    h = Math.imul(h, 16777619);
-  }
-  return (h >>> 0).toString(36).slice(0, 6);
-}
-
 function rewriteUrls(
   source: string,
   assets: Map<string, AssetEntry>,
@@ -305,29 +159,4 @@ ${pagesMarkup}
 </div>
 </body>
 </html>`;
-}
-
-function escapeHtml(s: string): string {
-  return s
-    .replace(/&/g, '&amp;')
-    .replace(/</g, '&lt;')
-    .replace(/>/g, '&gt;')
-    .replace(/"/g, '&quot;')
-    .replace(/'/g, '&#39;');
-}
-
-function escapeAttr(s: string): string {
-  return s.replace(/&/g, '&amp;').replace(/"/g, '&quot;');
-}
-
-function downloadBlob(blob: Blob, filename: string): void {
-  const url = URL.createObjectURL(blob);
-  const a = document.createElement('a');
-  a.href = url;
-  a.download = filename;
-  a.rel = 'noopener';
-  document.body.appendChild(a);
-  a.click();
-  a.remove();
-  setTimeout(() => URL.revokeObjectURL(url), 0);
 }

--- a/packages/core/src/app/lib/export-image.ts
+++ b/packages/core/src/app/lib/export-image.ts
@@ -1,0 +1,226 @@
+/**
+ * Pages as pictures — SVG, and PNG rasterised from it.
+ *
+ * The page is HTML, so the SVG is an HTML page wrapped in `<foreignObject>`.
+ * That has one hard consequence: an SVG handed to the canvas rasteriser is
+ * loaded in isolation, and it may not fetch anything. A stylesheet URL, a web
+ * font, an `<img src>` pointing at the server — all of them silently do not
+ * arrive, and what comes out is a page in fallback fonts with holes where the
+ * images were. So every referenced asset is fetched here and embedded as a
+ * `data:` URI before the SVG is built. Fonts installed on the reader's own
+ * machine still resolve by name; only fetched ones need embedding.
+ */
+
+import { designToCssVars } from './design';
+import {
+  downloadBlob,
+  findCssAssetUrls,
+  findHtmlAssetUrls,
+  renderPagesToHtml,
+  toAbsolute,
+} from './export-dom';
+import { type DocModule, type PageGeometry, resolvePageGeometry } from './sdk';
+import type { ExpandedPage } from './use-doc-pages';
+
+export type ImageFormat = 'png' | 'svg';
+
+export type ImageExportProgress = {
+  phase: 'rendering' | 'embedding' | 'drawing' | 'done';
+  current: number;
+  total: number;
+  percent: number;
+};
+
+/**
+ * Rasterised at twice the CSS size. A page printed at 1x is legible on screen
+ * and disappointing everywhere else — the moment someone drops it into a slide
+ * the text is soft. Twice is the cheapest size that survives that.
+ */
+const PNG_SCALE = 2;
+
+export async function exportDocAsImages(
+  doc: DocModule,
+  docId: string,
+  pages: ExpandedPage[],
+  format: ImageFormat,
+  onProgress?: (progress: ImageExportProgress) => void,
+): Promise<void> {
+  if (pages.length === 0) return;
+
+  const total = pages.length;
+  const geometry = resolvePageGeometry(doc.meta);
+  const report = (phase: ImageExportProgress['phase'], current: number, percent: number) =>
+    onProgress?.({ phase, current, total, percent });
+
+  report('rendering', 0, 2);
+  const pagesHtml = await renderPagesToHtml(pages, geometry, doc);
+
+  report('embedding', 0, 20);
+  const { css, html } = await embedAssets(pagesHtml, doc);
+
+  const files: { name: string; blob: Blob }[] = [];
+  for (let i = 0; i < html.length; i++) {
+    const svg = buildSvg(html[i] ?? '', css, geometry, doc);
+    const name = `${docId}-${String(i + 1).padStart(2, '0')}`;
+    if (format === 'svg') {
+      files.push({ name: `${name}.svg`, blob: new Blob([svg], { type: 'image/svg+xml' }) });
+    } else {
+      report('drawing', i + 1, 20 + Math.round(((i + 1) / total) * 75));
+      files.push({ name: `${name}.png`, blob: await rasterise(svg, geometry) });
+    }
+  }
+
+  report('done', total, 100);
+  await deliver(files, docId, format);
+}
+
+async function deliver(
+  files: { name: string; blob: Blob }[],
+  docId: string,
+  format: ImageFormat,
+): Promise<void> {
+  const only = files[0];
+  if (files.length === 1 && only) {
+    downloadBlob(only.blob, only.name);
+    return;
+  }
+  const { zipSync } = await import('fflate');
+  const tree: Record<string, Uint8Array> = {};
+  for (const file of files) tree[file.name] = new Uint8Array(await file.blob.arrayBuffer());
+  const zip = zipSync(tree as Parameters<typeof zipSync>[0]);
+  downloadBlob(new Blob([zip as BlobPart], { type: 'application/zip' }), `${docId}-${format}.zip`);
+}
+
+async function embedAssets(
+  pagesHtml: string[],
+  doc: DocModule,
+): Promise<{ css: string; html: string[] }> {
+  const { collectCss } = await import('./export-dom');
+  let css = collectCss();
+  const joined = pagesHtml.join('\n');
+  const urls = new Set<string>([...findHtmlAssetUrls(joined), ...findCssAssetUrls(css)]);
+
+  const replacements = new Map<string, string>();
+  for (const url of urls) {
+    const absolute = toAbsolute(url);
+    if (!absolute) continue;
+    try {
+      const res = await fetch(absolute);
+      if (!res.ok) continue;
+      const blob = await res.blob();
+      replacements.set(url, await blobToDataUrl(blob));
+    } catch {
+      /* An asset that will not load is left as it was: a broken picture in the
+         output is easier to diagnose than a silently missing one. */
+    }
+  }
+
+  for (const [from, to] of replacements) css = css.split(from).join(to);
+  const html = pagesHtml.map((page) => {
+    let out = page;
+    for (const [from, to] of replacements) out = out.split(from).join(to);
+    return out;
+  });
+
+  void doc;
+  return { css, html };
+}
+
+function blobToDataUrl(blob: Blob): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => resolve(String(reader.result));
+    reader.onerror = () => reject(reader.error);
+    reader.readAsDataURL(blob);
+  });
+}
+
+/**
+ * The markup has to come out as XML, not HTML.
+ *
+ * `foreignObject` content is parsed by the XML parser, which stops at the first
+ * `<br>` or `<img>` that never closes — and the failure arrives as an image that
+ * will not load, with nothing said about why. So the page is parsed as HTML into
+ * a real tree and serialised back out as XML, which closes those tags properly.
+ *
+ * The design variables live on the page host, and renderPagesToHtml returns the
+ * host's innerHTML, so they are not in the markup and have to be put back.
+ */
+function buildSvg(pageHtml: string, css: string, geometry: PageGeometry, doc: DocModule): string {
+  const SVG_NS = 'http://www.w3.org/2000/svg';
+  const XHTML_NS = 'http://www.w3.org/1999/xhtml';
+
+  const svg = document.createElementNS(SVG_NS, 'svg');
+  svg.setAttribute('width', String(geometry.width));
+  svg.setAttribute('height', String(geometry.height));
+  svg.setAttribute('viewBox', `0 0 ${geometry.width} ${geometry.height}`);
+
+  const foreign = document.createElementNS(SVG_NS, 'foreignObject');
+  foreign.setAttribute('x', '0');
+  foreign.setAttribute('y', '0');
+  foreign.setAttribute('width', String(geometry.width));
+  foreign.setAttribute('height', String(geometry.height));
+
+  const wrapper = document.createElementNS(XHTML_NS, 'div');
+  const vars = doc.design ? designToCssVars(doc.design) : null;
+  const declarations = vars
+    ? Object.entries(vars)
+        .map(([name, value]) => `${name}:${value}`)
+        .join(';')
+    : '';
+  wrapper.setAttribute(
+    'style',
+    `${declarations};width:${geometry.width}px;height:${geometry.height}px`,
+  );
+
+  const style = document.createElementNS(XHTML_NS, 'style');
+  style.appendChild(document.createTextNode(css));
+  wrapper.appendChild(style);
+
+  const content = document.createElementNS(XHTML_NS, 'div');
+  content.innerHTML = pageHtml;
+  wrapper.appendChild(content);
+
+  foreign.appendChild(wrapper);
+  svg.appendChild(foreign);
+  return new XMLSerializer().serializeToString(svg);
+}
+
+/**
+ * SVG → canvas → PNG.
+ *
+ * The SVG goes in as a `data:` URI, not a `blob:` one. Chrome taints a canvas
+ * that has been drawn from a blob-backed SVG containing `<foreignObject>`, and
+ * refuses to export it; the same markup as a data URI draws and exports fine.
+ * Verified against Chrome 151 — a plain SVG is clean either way, so the taint
+ * follows the foreignObject and the URL scheme together, not either alone.
+ */
+async function rasterise(svg: string, geometry: PageGeometry): Promise<Blob> {
+  const source = `data:image/svg+xml;charset=utf-8,${encodeURIComponent(svg)}`;
+
+  const image = new Image();
+  await new Promise<void>((resolve, reject) => {
+    image.onload = () => resolve();
+    image.onerror = () => reject(new Error('The page could not be drawn as an image.'));
+    image.src = source;
+  });
+
+  const canvas = document.createElement('canvas');
+  canvas.width = Math.round(geometry.width * PNG_SCALE);
+  canvas.height = Math.round(geometry.height * PNG_SCALE);
+  const ctx = canvas.getContext('2d');
+  if (!ctx) throw new Error('This browser would not give a 2D canvas.');
+  /* A page is paper. A transparent PNG dropped on a dark slide shows black
+     body text on black. */
+  ctx.fillStyle = '#ffffff';
+  ctx.fillRect(0, 0, canvas.width, canvas.height);
+  ctx.setTransform(PNG_SCALE, 0, 0, PNG_SCALE, 0, 0);
+  ctx.drawImage(image, 0, 0, geometry.width, geometry.height);
+
+  return await new Promise<Blob>((resolve, reject) => {
+    canvas.toBlob(
+      (blob) => (blob ? resolve(blob) : reject(new Error('The canvas produced no image.'))),
+      'image/png',
+    );
+  });
+}

--- a/packages/core/src/app/lib/page-range.test.ts
+++ b/packages/core/src/app/lib/page-range.test.ts
@@ -1,0 +1,95 @@
+/**
+ * Page ranges, where off-by-one lives.
+ *
+ * The reader types "1" and means the first page; the array wants index 0. Every
+ * assertion here is about that seam, plus the two answers that must stay
+ * distinct: "nothing you typed names a page" and "you selected no pages". Only
+ * one of them should ever start a download, and neither should download
+ * everything by accident.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { describeSelection, parseRange, resolveSelection } from './page-range';
+
+describe('parseRange', () => {
+  it('reads single pages, one-based', () => {
+    expect(parseRange('1', 5)).toEqual([0]);
+    expect(parseRange('3', 5)).toEqual([2]);
+  });
+
+  it('reads spans, inclusive at both ends', () => {
+    expect(parseRange('1-3', 5)).toEqual([0, 1, 2]);
+    expect(parseRange('4-5', 5)).toEqual([3, 4]);
+  });
+
+  it('reads a mixed list, sorted and deduplicated', () => {
+    expect(parseRange('5,1,2-3,1', 9)).toEqual([0, 1, 2, 4]);
+  });
+
+  /* A range typed backwards is a range, not a mistake worth refusing. */
+  it('accepts a span written the wrong way round', () => {
+    expect(parseRange('5-2', 9)).toEqual([1, 2, 3, 4]);
+  });
+
+  /* 中文鍵盤打出來的全形數字和破折號，使用者不會察覺自己打的是全形。 */
+  it('accepts full-width digits and dashes', () => {
+    expect(parseRange('１-３', 5)).toEqual([0, 1, 2]);
+    expect(parseRange('２，４', 5)).toEqual([1, 3]);
+  });
+
+  it('clips to the document rather than inventing pages', () => {
+    expect(parseRange('3-99', 5)).toEqual([2, 3, 4]);
+    expect(parseRange('0-2', 5)).toEqual([0, 1]);
+  });
+
+  /*
+   * The important negative: nothing usable must be null, never an empty array.
+   * An empty array flowing on would start a download of no pages.
+   */
+  it('returns null when nothing names a real page', () => {
+    expect(parseRange('', 5)).toBeNull();
+    expect(parseRange('   ', 5)).toBeNull();
+    expect(parseRange('abc', 5)).toBeNull();
+    expect(parseRange('9', 5)).toBeNull();
+    expect(parseRange('-', 5)).toBeNull();
+  });
+});
+
+describe('resolveSelection', () => {
+  it('all covers the document', () => {
+    expect(resolveSelection({ kind: 'all' }, 3, 2)).toEqual([0, 1, 2]);
+  });
+
+  it('current is the page being read, one-based in and zero-based out', () => {
+    expect(resolveSelection({ kind: 'current' }, 5, 1)).toEqual([0]);
+    expect(resolveSelection({ kind: 'current' }, 5, 4)).toEqual([3]);
+  });
+
+  /* currentPage can lag the document while it reflows; it must not index past. */
+  it('clamps a current page outside the document', () => {
+    expect(resolveSelection({ kind: 'current' }, 3, 99)).toEqual([2]);
+    expect(resolveSelection({ kind: 'current' }, 3, 0)).toEqual([0]);
+  });
+
+  it('has nothing to give for an empty document', () => {
+    expect(resolveSelection({ kind: 'all' }, 0, 1)).toBeNull();
+  });
+});
+
+describe('describeSelection', () => {
+  it('counts what the button is about to do', () => {
+    expect(describeSelection({ kind: 'all' }, 4, 1)).toEqual({ count: 4, valid: true });
+    expect(describeSelection({ kind: 'current' }, 4, 2)).toEqual({ count: 1, valid: true });
+    expect(describeSelection({ kind: 'custom', text: '2-3' }, 4, 1)).toEqual({
+      count: 2,
+      valid: true,
+    });
+  });
+
+  it('reports an unreadable range as invalid, not as zero pages', () => {
+    expect(describeSelection({ kind: 'custom', text: 'nope' }, 4, 1)).toEqual({
+      count: 0,
+      valid: false,
+    });
+  });
+});

--- a/packages/core/src/app/lib/page-range.ts
+++ b/packages/core/src/app/lib/page-range.ts
@@ -1,0 +1,90 @@
+/**
+ * Which pages a download covers.
+ *
+ * The custom field takes what a print dialog takes — `2`, `1-3`, `2,5,7-9` —
+ * because that is the notation people already have in their fingers. Everything
+ * here is 1-based on the way in and 0-based on the way out, which is where this
+ * kind of code usually goes wrong: the reader says "page 1" and the array
+ * wants index 0.
+ */
+
+export type PageSelection =
+  | { kind: 'all' }
+  | { kind: 'current' }
+  | { kind: 'custom'; text: string };
+
+/**
+ * Zero-based indices, ascending, no duplicates.
+ *
+ * An unparseable or empty custom range returns null rather than an empty list:
+ * "I could not read that" and "you asked for no pages" are different answers,
+ * and only one of them should be allowed to start a download.
+ */
+export function resolveSelection(
+  selection: PageSelection,
+  total: number,
+  currentPage: number,
+): number[] | null {
+  if (total <= 0) return null;
+  if (selection.kind === 'all') return Array.from({ length: total }, (_, i) => i);
+  if (selection.kind === 'current') {
+    const index = clamp(currentPage, 1, total) - 1;
+    return [index];
+  }
+  return parseRange(selection.text, total);
+}
+
+/** `2,5,7-9` → [1,4,6,7,8]. Null when nothing in the text names a real page. */
+export function parseRange(text: string, total: number): number[] | null {
+  if (text.trim() === '') return null;
+
+  const wanted = new Set<number>();
+  let sawSomething = false;
+
+  for (const chunk of text.split(/[,，\s]+/)) {
+    if (chunk === '') continue;
+    /* Full-width digits and dashes: a Chinese keyboard produces them without
+       the typist noticing, and rejecting them reads as the field being broken. */
+    const plain = chunk
+      .replace(/[０-９]/g, (d) => String(d.charCodeAt(0) - 0xff10))
+      .replace(/[–—ー－]/g, '-');
+
+    const span = /^(\d+)-(\d+)$/.exec(plain);
+    if (span) {
+      const from = Number(span[1]);
+      const to = Number(span[2]);
+      if (!Number.isFinite(from) || !Number.isFinite(to)) continue;
+      /* `5-2` is a range someone typed backwards, not an empty one. */
+      const [lo, hi] = from <= to ? [from, to] : [to, from];
+      for (let page = Math.max(1, lo); page <= Math.min(total, hi); page++) {
+        wanted.add(page - 1);
+        sawSomething = true;
+      }
+      continue;
+    }
+
+    if (/^\d+$/.test(plain)) {
+      const page = Number(plain);
+      if (page >= 1 && page <= total) {
+        wanted.add(page - 1);
+        sawSomething = true;
+      }
+    }
+  }
+
+  if (!sawSomething || wanted.size === 0) return null;
+  return [...wanted].sort((a, b) => a - b);
+}
+
+export function describeSelection(
+  selection: PageSelection,
+  total: number,
+  currentPage: number,
+): { count: number; valid: boolean } {
+  const pages = resolveSelection(selection, total, currentPage);
+  return { count: pages?.length ?? 0, valid: pages !== null };
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value));
+}

--- a/packages/core/src/app/routes/doc.tsx
+++ b/packages/core/src/app/routes/doc.tsx
@@ -4,21 +4,25 @@ import {
   Check,
   Download,
   FileCode2,
+  FileImage,
   FileText,
+  Image,
   Loader2,
   Maximize,
   Minimize,
   Minus,
   MousePointerClick,
   MoveHorizontal,
+  MoveVertical,
   Palette,
+  Percent,
   Plus,
-  Scan,
 } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 import { Link, useParams } from 'react-router-dom';
 import { DesignPanel } from '../components/design-panel/design-panel';
 import { DesignProvider } from '../components/design-panel/design-provider';
+import { DocSearch } from '../components/doc-search';
 import { DocSidebar } from '../components/doc-sidebar';
 import { Inspector } from '../components/inspector/inspector';
 import { PageFrame } from '../components/page-frame';
@@ -26,8 +30,10 @@ import { ThemeToggle } from '../components/theme-toggle';
 import { Menu, MenuItem } from '../components/ui/menu';
 import { useAgentBridge } from '../lib/agent-bridge';
 import { exportDocAsHtml } from '../lib/export-html';
+import { exportDocAsImages } from '../lib/export-image';
 import { exportDocAsPdf } from '../lib/export-pdf';
 import { type OutlineEntry, useDocOutline } from '../lib/outline';
+import { describeSelection, type PageSelection, resolveSelection } from '../lib/page-range';
 import { nextFrame, waitForFonts } from '../lib/print-ready';
 import { scanDocument } from '../lib/scan';
 import { resolvePageGeometry } from '../lib/sdk';
@@ -35,16 +41,20 @@ import { useDocModule } from '../lib/use-doc-module';
 import { useDocPages } from '../lib/use-doc-pages';
 import { cn } from '../lib/utils';
 
-type DownloadFormat = 'pdf' | 'html';
+type DownloadFormat = 'pdf' | 'html' | 'png' | 'svg';
 
 const DOWNLOAD_LABEL: Record<DownloadFormat, string> = {
   pdf: 'PDF',
   html: 'HTML',
+  png: 'PNG',
+  svg: 'SVG',
 };
 
 const DOWNLOAD_FORMATS = [
   { format: 'pdf' as const, label: 'PDF', hint: 'True page size, print-ready', icon: FileText },
   { format: 'html' as const, label: 'HTML', hint: 'Self-contained, printable', icon: FileCode2 },
+  { format: 'png' as const, label: 'PNG', hint: 'Pixels, 2x — for slides and chat', icon: Image },
+  { format: 'svg' as const, label: 'SVG', hint: 'Vector, keeps text as text', icon: FileImage },
 ];
 
 const GUTTER = 48;
@@ -98,6 +108,8 @@ export function Doc() {
     null,
   );
   const [downloaded, setDownloaded] = useState<DownloadFormat | null>(null);
+  const [selection, setSelection] = useState<PageSelection>({ kind: 'all' });
+  const [customRange, setCustomRange] = useState('');
   const [designOpen, setDesignOpen] = useState(false);
   const [inspecting, setInspecting] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
@@ -217,14 +229,33 @@ export function Doc() {
 
   const runDownload = async (format: DownloadFormat) => {
     if (!doc || !docId || download) return;
+
+    /*
+     * The pages are chosen here, once, and every exporter is handed the subset
+     * rather than the whole document plus a range to obey. An exporter that has
+     * to remember to filter is an exporter that will one day forget.
+     */
+    const wanted = resolveSelection(
+      selection.kind === 'custom' ? { kind: 'custom', text: customRange } : selection,
+      pages.length,
+      currentPage,
+    );
+    if (!wanted) return;
+    const chosen = wanted.map((index) => pages[index]).filter((page) => page !== undefined);
+    if (chosen.length === 0) return;
+
     setDownload({ format, percent: 0 });
     try {
       if (format === 'pdf') {
-        await exportDocAsPdf(doc, docId, pages, (progress) =>
+        await exportDocAsPdf(doc, docId, chosen, (progress) =>
           setDownload({ format, percent: progress.percent }),
         );
+      } else if (format === 'html') {
+        await exportDocAsHtml(doc, docId, chosen);
       } else {
-        await exportDocAsHtml(doc, docId, pages);
+        await exportDocAsImages(doc, docId, chosen, format, (progress) =>
+          setDownload({ format, percent: progress.percent }),
+        );
       }
       setDownloaded(format);
       setTimeout(() => setDownloaded(null), 2000);
@@ -232,6 +263,13 @@ export function Doc() {
       setDownload(null);
     }
   };
+
+  /* What the menu is about to do, so nobody has to count commas themselves. */
+  const chosenPages = describeSelection(
+    selection.kind === 'custom' ? { kind: 'custom', text: customRange } : selection,
+    pages.length,
+    currentPage,
+  );
 
   const zoom = (delta: number) => {
     setManualScale((prev) =>
@@ -324,8 +362,9 @@ export function Doc() {
         <h1 className="truncate text-center font-medium text-sm">{doc.meta?.title ?? docId}</h1>
 
         <div className="flex items-center justify-end gap-3">
-          <span className="hidden whitespace-nowrap font-mono text-muted-foreground text-xs tabular-nums sm:inline">
-            {currentPage} / {pages.length}
+          <span className="hidden items-center gap-1.5 sm:flex">
+            <PageJump page={currentPage} total={pages.length} onJump={scrollToPage} />
+            <DocSearch scrollRef={scrollRef} pagesRef={pagesRef} onFoundPage={setCurrentPage} />
           </span>
 
           <div className="flex items-center gap-0.5 rounded-md border border-border px-1 py-0.5">
@@ -350,12 +389,19 @@ export function Doc() {
             >
               <MoveHorizontal className="size-3.5" />
             </IconButton>
+            {/* Fit-width moves the page sideways to the edges, fit-page moves it
+                up and down to them. Both used to be a square-ish glyph, and the
+                fit-page one was the same square as fullscreen — three controls,
+                two shapes, no way to tell which did what without clicking. */}
             <IconButton
               label="Fit page"
               onClick={() => fitTo('fit-page')}
               active={manualScale === null && zoomMode === 'fit-page'}
             >
-              <Scan className="size-3.5" />
+              <MoveVertical className="size-3.5" />
+            </IconButton>
+            <IconButton label="Actual size (100%)" onClick={actualSize}>
+              <Percent className="size-3.5" />
             </IconButton>
           </div>
 
@@ -419,23 +465,37 @@ export function Doc() {
               </button>
             )}
           >
-            {(close) =>
-              DOWNLOAD_FORMATS.map(({ format, label, hint, icon: Icon }) => (
-                <MenuItem
-                  key={format}
-                  onClick={() => {
-                    close();
-                    void runDownload(format);
-                  }}
-                >
-                  <Icon className="size-3.5 flex-none" />
-                  <span className="flex-1">
-                    {label}
-                    <span className="block text-[10px] text-muted-foreground">{hint}</span>
-                  </span>
-                </MenuItem>
-              ))
-            }
+            {(close) => (
+              <>
+                {/* Which pages, before which format. A reader who picks PDF and
+                    then discovers they exported forty pages has already waited
+                    for all forty. */}
+                <PageChoice
+                  selection={selection}
+                  custom={customRange}
+                  currentPage={currentPage}
+                  total={pages.length}
+                  onSelection={setSelection}
+                  onCustom={setCustomRange}
+                />
+                {DOWNLOAD_FORMATS.map(({ format, label, hint, icon: Icon }) => (
+                  <MenuItem
+                    key={format}
+                    disabled={!chosenPages.valid}
+                    onClick={() => {
+                      close();
+                      void runDownload(format);
+                    }}
+                  >
+                    <Icon className="size-3.5 flex-none" />
+                    <span className="flex-1">
+                      {label}
+                      <span className="block text-[10px] text-muted-foreground">{hint}</span>
+                    </span>
+                  </MenuItem>
+                ))}
+              </>
+            )}
           </Menu>
         </div>
       </header>
@@ -488,6 +548,144 @@ export function Doc() {
   // exists while `open-doc dev` is running.
   if (!import.meta.env.DEV || !docId) return view;
   return <DesignProvider docId={docId}>{view}</DesignProvider>;
+}
+
+/**
+ * 全部／此頁／自訂 —— 和列印對話框問的是同一件事，因為那是使用者已經會的問法。
+ *
+ * 自訂欄位只在被選中時出現。三個選項配一個永遠佔著位置的空欄位，會讓人以為那是
+ * 必填的。
+ */
+function PageChoice({
+  selection,
+  custom,
+  currentPage,
+  total,
+  onSelection,
+  onCustom,
+}: {
+  selection: PageSelection;
+  custom: string;
+  currentPage: number;
+  total: number;
+  onSelection: (selection: PageSelection) => void;
+  onCustom: (text: string) => void;
+}) {
+  const options = [
+    { kind: 'all' as const, label: 'All', hint: `${total}` },
+    { kind: 'current' as const, label: 'This page', hint: `${currentPage}` },
+    { kind: 'custom' as const, label: 'Custom', hint: '' },
+  ];
+  const chosen = describeSelection(
+    selection.kind === 'custom' ? { kind: 'custom', text: custom } : selection,
+    total,
+    currentPage,
+  );
+
+  return (
+    <div className="border-border border-b px-1 pt-1 pb-2">
+      <p className="px-1 pb-1 text-[10px] text-muted-foreground uppercase tracking-wide">Pages</p>
+      <div className="flex gap-0.5">
+        {options.map((option) => (
+          <button
+            key={option.kind}
+            type="button"
+            onClick={(event) => {
+              event.stopPropagation();
+              onSelection(
+                option.kind === 'custom' ? { kind: 'custom', text: custom } : { kind: option.kind },
+              );
+            }}
+            className={cn(
+              'flex-1 rounded px-2 py-1 text-[11px] transition-colors hover:bg-accent',
+              selection.kind === option.kind && 'bg-accent text-foreground',
+            )}
+          >
+            {option.label}
+            {option.hint && (
+              <span className="ml-1 font-mono text-[10px] text-muted-foreground">
+                {option.hint}
+              </span>
+            )}
+          </button>
+        ))}
+      </div>
+      {selection.kind === 'custom' && (
+        <input
+          value={custom}
+          onChange={(event) => onCustom(event.target.value)}
+          onClick={(event) => event.stopPropagation()}
+          placeholder="e.g. 1-3, 5"
+          aria-label="Pages to download"
+          aria-invalid={!chosen.valid}
+          className={cn(
+            'mt-1.5 w-full rounded border border-border bg-transparent px-2 py-1 text-[11px] outline-none placeholder:text-muted-foreground focus:border-foreground/40',
+            !chosen.valid && custom !== '' && 'border-foreground/40',
+          )}
+        />
+      )}
+      <p className="px-1 pt-1.5 text-[10px] text-muted-foreground">
+        {chosen.valid
+          ? `${chosen.count} page${chosen.count === 1 ? '' : 's'} will be downloaded`
+          : 'Type page numbers, like 1-3, 5'}
+      </p>
+    </div>
+  );
+}
+
+/**
+ * 頁碼既是顯示也是輸入。
+ *
+ * 只在編輯時才變成受控欄位：一直受控的話，讀者捲動時每一次頁碼更新都會把游標推
+ * 回去，打到一半的數字就消失了。
+ */
+function PageJump({
+  page,
+  total,
+  onJump,
+}: {
+  page: number;
+  total: number;
+  onJump: (page: number) => void;
+}) {
+  const [draft, setDraft] = useState<string | null>(null);
+
+  const commit = (raw: string) => {
+    const wanted = Number(raw.replace(/[０-９]/g, (d) => String(d.charCodeAt(0) - 0xff10)));
+    setDraft(null);
+    if (!Number.isFinite(wanted) || wanted < 1) return;
+    onJump(Math.min(total, Math.round(wanted)));
+  };
+
+  return (
+    <span className="flex items-center whitespace-nowrap font-mono text-muted-foreground text-xs tabular-nums">
+      <input
+        value={draft ?? String(page)}
+        onChange={(event) => setDraft(event.target.value)}
+        onFocus={(event) => {
+          setDraft(String(page));
+          event.target.select();
+        }}
+        onBlur={(event) => commit(event.target.value)}
+        onKeyDown={(event) => {
+          if (event.key === 'Enter') {
+            event.preventDefault();
+            event.currentTarget.blur();
+          }
+          if (event.key === 'Escape') {
+            setDraft(null);
+            event.currentTarget.blur();
+          }
+        }}
+        aria-label={`Page number, ${total} pages`}
+        title="Go to page"
+        inputMode="numeric"
+        className="w-7 rounded bg-transparent text-right outline-none transition-colors hover:bg-accent focus:bg-accent focus:text-foreground"
+      />
+      <span className="px-1">/</span>
+      <span>{total}</span>
+    </span>
+  );
 }
 
 function IconButton({

--- a/packages/core/src/app/styles.css
+++ b/packages/core/src/app/styles.css
@@ -70,3 +70,28 @@
     -webkit-font-smoothing: antialiased;
   }
 }
+
+/* Search hits.
+ *
+ * Drawn with the CSS Custom Highlight API, so nothing in the page is wrapped or
+ * rewritten to show a match. Wrapping matches in <mark> would mean editing a
+ * tree React owns, and the next render would throw the marks away — or worse,
+ * keep them and lose the reader's place. Highlights are ranges held beside the
+ * DOM instead, which is what they are for.
+ *
+ * A browser without the API shows no highlight; the page-to-page jumping still
+ * works, so search degrades to "take me there" rather than breaking.
+ */
+/* Literal colours, deliberately. These paint the sheet, and the sheet is paper —
+   it does not follow the viewer's theme. A chrome token here resolves to
+   near-white in dark mode and disappears on a white page, which is the leak the
+   guidelines warn about, arriving as an invisible highlight rather than an
+   obviously wrong one. Amber is what every reader already reads as "found". */
+::highlight(od-search) {
+  background-color: rgb(255 214 0 / 0.42);
+  color: inherit;
+}
+::highlight(od-search-active) {
+  background-color: rgb(255 138 0 / 0.62);
+  color: inherit;
+}


### PR DESCRIPTION
## What

Five things in the viewer toolbar.

- **Distinct zoom icons.** Fit-page and fullscreen were the same square glyph. Fit-page is now an up-down arrow, pairing with the left-right arrow that fits the width; a new per-cent button resets the zoom to 100%.
- **Page jump.** The page counter is an input — type a number to go there.
- **Find in document.** Beside the counter. Live match count, next/previous, amber highlight.
- **PNG and SVG download**, alongside PDF and HTML. One page is one file; several arrive as a zip.
- **Page range.** Download asks which pages first — all, this one, or `1-3, 5`. Full-width digits are accepted. When the range cannot be read, every format is disabled: there is no way to start a download of no pages.

PDF keeps the existing print path.

## Three things only running it found

**`foreignObject` content is parsed as XML.** `innerHTML` produces HTML, so an unclosed `<br>` failed the whole image load — reported as a bare `onerror` with no reason. Serialised through `XMLSerializer` instead.

**Chrome taints a canvas drawn from a `blob:`-backed SVG containing `foreignObject`** and refuses to export it. The same markup as a `data:` URI is clean. A plain SVG is fine either way, so the taint needs both conditions; the control test is recorded in the comment on `rasterise`.

**The search highlight used `--primary`,** a chrome token. In the dark theme it resolves to near-white, and the page is white paper — the highlight was invisible. That is the chrome-token leak `viewer-ui-guidelines` rule 4 warns about, arriving as nothing rather than as something obviously wrong. The highlight paints the sheet, so it uses literal amber, with the reason written down.

## Notes

- No `⌘F` binding: that is the browser's own find, and the guidelines say new shortcuts must not collide with it.
- Matches are painted with the CSS Custom Highlight API rather than wrapped in `<mark>` — wrapping edits a tree React owns. A browser without the API still navigates between hits.
- `export-dom.ts` is extracted from `export-html.ts` so both exporters draw the document offscreen the same way; two copies would drift on font waiting or design variables, and only an exported file would show it.
- 13 new tests cover page-range parsing. `pnpm check`, `pnpm typecheck`, `pnpm test` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011gA7SrWo14QN3uMhEcjP9J