### PR TITLE
Edit text wherever it lives, in one field

### DIFF
--- a/.changeset/inspector-prop-text.md
+++ b/.changeset/inspector-prop-text.md
@@ -2,8 +2,22 @@
 '@open-document/core': minor
 ---
 
-The inspector can edit text a component receives as props. Clicking a heading
-whose source reads `{agency}　{kind}` used to report that the text was produced
-by code; the words are found at the call site and edited there, leaving the
-expression alone. Two call sites of the same component are told apart by what
-is on screen, and anything that cannot be resolved that way is still refused.
+The inspector edits text wherever it actually lives.
+
+A document written through helpers used to report `text is produced by code` for
+most of itself: the words behind `{agency}`, `{line}` or `{children}` are not in
+the element that renders them. Each child of the selected element now resolves
+on its own — to a call site's attribute, to one entry of an array the call site
+passed, to whatever sits between its tags, or to a template literal. Runs that
+cannot be told apart by what is on screen are still refused, so a save never
+rewrites a sibling.
+
+Resolving the element as a whole was also why `{label}：{value}` offered nothing
+but the colon: the literal was found, so the props were never looked for.
+
+A contents row selects the heading it was generated from, and scrolls to it —
+the list stays a view of the headings rather than something to type into.
+
+The text panel is one field instead of one per run. A sentence interrupted by
+five `<code>` spans is still a sentence; it now reads like one, with the markup
+between the words as inert chips.

--- a/.changeset/inspector-prop-text.md
+++ b/.changeset/inspector-prop-text.md
@@ -1,0 +1,9 @@
+---
+'@open-document/core': minor
+---
+
+The inspector can edit text a component receives as props. Clicking a heading
+whose source reads `{agency}　{kind}` used to report that the text was produced
+by code; the words are found at the call site and edited there, leaving the
+expression alone. Two call sites of the same component are told apart by what
+is on screen, and anything that cannot be resolved that way is still refused.

--- a/packages/core/src/app/components/inspector/inspector.tsx
+++ b/packages/core/src/app/components/inspector/inspector.tsx
@@ -250,7 +250,7 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
   );
 
   const saveText = async () => {
-    if (!target || dirty.length === 0 || busy) return;
+    if (!target || !selected || dirty.length === 0 || busy) return;
     setBusy(true);
     try {
       for (const part of dirty) {
@@ -263,6 +263,7 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
             column: target.column,
             index: part.index,
             expected: part.value,
+            shown: normalize(selected.anchor.textContent ?? ''),
             text: drafts[part.index],
           }),
         });

--- a/packages/core/src/app/components/inspector/inspector.tsx
+++ b/packages/core/src/app/components/inspector/inspector.tsx
@@ -1,6 +1,7 @@
 import { Check, Loader2, MessageSquarePlus, X } from 'lucide-react';
 import {
   type CSSProperties,
+  Fragment,
   useCallback,
   useEffect,
   useLayoutEffect,
@@ -42,7 +43,13 @@ function normalize(value: string): string {
 }
 
 function targetFrom(el: Element | null): InspectorTarget | null {
-  const host = (el as HTMLElement | null)?.closest?.(`[${LOC_ATTR}]`) as HTMLElement | null;
+  // A contents row is generated from a heading and written nowhere; the words
+  // to edit are the heading's. Clicking the row selects that instead, so the
+  // list stays what it is — a view — and still answers to a click.
+  const row = (el as HTMLElement | null)?.closest?.('[data-od-toc-entry]') as HTMLElement | null;
+  const heading = row?.dataset.odTocEntry ? document.getElementById(row.dataset.odTocEntry) : null;
+  const from = heading ?? el;
+  const host = (from as HTMLElement | null)?.closest?.(`[${LOC_ATTR}]`) as HTMLElement | null;
   const raw = host?.getAttribute(LOC_ATTR);
   if (!host || !raw) return null;
   const [line, column] = raw.split(':').map(Number);
@@ -136,6 +143,7 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
   const [busy, setBusy] = useState(false);
   const [status, setStatus] = useState<string | null>(null);
   const panelRef = useRef<HTMLElement>(null);
+  const editorRef = useRef<HTMLDivElement>(null);
 
   useLayoutEffect(() => setContainer(containerRef.current), [containerRef]);
 
@@ -157,6 +165,12 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
       if (!target) return;
       e.preventDefault();
       e.stopPropagation();
+      // A contents row sends the selection to a heading pages away. Without
+      // this the panel fills in and the document sits where it was, which
+      // reads as nothing having happened.
+      if (!target.anchor.contains(e.target as Node)) {
+        target.anchor.scrollIntoView({ block: 'center', behavior: 'smooth' });
+      }
       setSelected(target);
       setStatus(null);
       setNote('');
@@ -361,18 +375,70 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
               </div>
             ) : target.editable ? (
               <>
-                <div className="mt-1 space-y-1.5">
-                  {target.parts.map((part, index) =>
-                    part.kind === 'markup' ? (
-                      <div
+                {/*
+                 * One field, not one per run. A sentence interrupted by five
+                 * <code> spans is still one sentence, and bordering each
+                 * fragment turned a paragraph into eleven stacked boxes.
+                 *
+                 * The runs are laid out as the sentence reads, with the markup
+                 * between them as inert chips. Nothing re-renders while typing:
+                 * the children never change, so React leaves the DOM — and the
+                 * caret — alone, and the text is read back out of it.
+                 */}
+                {target.parts.length > 1 ? (
+                  // biome-ignore lint/a11y/useSemanticElements: a textarea cannot hold the inert markup chips
+                  <div
+                    key={`${target.line}:${target.column}`}
+                    ref={editorRef}
+                    contentEditable
+                    suppressContentEditableWarning
+                    role="textbox"
+                    tabIndex={0}
+                    aria-label="Text"
+                    onInput={() => {
+                      const host = editorRef.current;
+                      if (!host) return;
+                      const next: Record<number, string> = {};
+                      for (const run of host.querySelectorAll<HTMLElement>('[data-run]')) {
+                        next[Number(run.dataset.run)] = run.textContent ?? '';
+                      }
+                      setDrafts(next);
+                    }}
+                    onKeyDown={(e) => {
+                      // A newline would be a <br> the runs cannot carry.
+                      if (e.key === 'Enter') {
+                        e.preventDefault();
+                        void saveText();
+                      }
+                    }}
+                    className="mt-1 rounded border border-border px-2 py-1.5 text-xs leading-relaxed outline-none focus-within:border-foreground/40"
+                  >
+                    {target.parts.map((part, index) =>
+                      part.kind === 'markup' ? (
+                        // A chip carries no whitespace, so `real<code>/<code>`
+                        // is one unbreakable word without these.
                         // biome-ignore lint/suspicious/noArrayIndexKey: parts are positional
-                        key={`m${index}`}
-                        className="rounded border border-border border-dashed px-2 py-1 font-mono text-[10px] text-muted-foreground"
-                        title="Markup is kept as written"
-                      >
-                        {part.label}
-                      </div>
-                    ) : (
+                        <Fragment key={`m${index}`}>
+                          <wbr />
+                          <span
+                            contentEditable={false}
+                            title="Markup is kept as written"
+                            className="mx-0.5 select-none rounded bg-muted px-1 py-px font-mono text-[10px] text-muted-foreground"
+                          >
+                            {part.label}
+                          </span>
+                          <wbr />
+                        </Fragment>
+                      ) : (
+                        <span key={`t${part.index}`} data-run={part.index}>
+                          {part.value}
+                        </span>
+                      ),
+                    )}
+                  </div>
+                ) : (
+                  target.parts.map((part) =>
+                    part.kind === 'markup' ? null : (
                       <textarea
                         key={`t${part.index}`}
                         value={drafts[part.index] ?? part.value}
@@ -383,14 +449,22 @@ export function Inspector({ docId, containerRef, onExit }: Props) {
                           if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) void saveText();
                         }}
                         rows={Math.min(
-                          6,
-                          Math.ceil((drafts[part.index] ?? part.value).length / 28) + 1,
+                          14,
+                          Math.max(
+                            2,
+                            (drafts[part.index] ?? part.value).split('\n').length,
+                            Math.ceil((drafts[part.index] ?? part.value).length / 40),
+                          ),
                         )}
-                        className="w-full resize-y rounded border border-border bg-transparent px-2 py-1.5 text-xs outline-none focus:border-foreground/40"
+                        className={`mt-1 w-full resize-y rounded border border-border bg-transparent px-2 py-1.5 outline-none focus:border-foreground/40 ${
+                          selected?.tag === 'pre'
+                            ? 'whitespace-pre font-mono text-[11px]'
+                            : 'text-xs'
+                        }`}
                       />
                     ),
-                  )}
-                </div>
+                  )
+                )}
                 <button
                   type="button"
                   onClick={saveText}

--- a/packages/core/src/app/components/table-of-contents.tsx
+++ b/packages/core/src/app/components/table-of-contents.tsx
@@ -50,6 +50,10 @@ export function TableOfContents({
       {entries.map((entry) => (
         <div
           key={entry.id}
+          /* Which heading this line stands for. The inspector follows it: a
+           * contents row holds no text of its own, so clicking one has to land
+           * on the heading that produced it. */
+          data-od-toc-entry={entry.id}
           style={{
             display: 'flex',
             alignItems: 'baseline',

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -107,6 +107,208 @@ describe('text that comes from props', () => {
   });
 });
 
+// A helper that puts half its words in an attribute and half between its tags,
+// with a literal of its own in between. All three used to be resolved as one:
+// finding the colon meant the props were never looked for, so the inspector
+// offered the colon and nothing else.
+const VIA_CHILDREN = `const Section = ({ name, children }: { name: string; children: ReactNode }) => (
+  <div style={hang}>
+    {name}：{children}
+  </div>
+);
+
+const Page = () => (
+  <div>
+    <Section name="主旨">本府訂於115年10月14日辦理研習營。</Section>
+    <Section name="說明">依本府115年度數位人才培育計畫辦理。</Section>
+  </div>
+);
+`;
+
+const VIA_CHILDREN_DIV = { line: 2, column: 2 };
+
+// Five contact lines rendered by one element. The words are entries of an
+// array the call site passed, so the click resolves to an array element.
+const VIA_MAP = `const Contact = ({ lines }: { lines: string[] }) => (
+  <div style={caption}>
+    {lines.map((line) => (
+      <div key={line}>{line}</div>
+    ))}
+  </div>
+);
+
+const Page = () => (
+  <div>
+    <Contact lines={['地址：000範例市範例路1號', '承辦人：陳小華']} />
+  </div>
+);
+`;
+
+const VIA_MAP_DIV = { line: 4, column: 6 };
+
+const VIA_PAIRS = `const Fields = ({ rows }: { rows: [string, string][] }) => (
+  <div style={caption}>
+    {rows.map(([label, value]) => (
+      <div key={label}>
+        {label}：{value}
+      </div>
+    ))}
+  </div>
+);
+
+const Page = () => (
+  <div>
+    <Fields
+      rows={[
+        ['發文日期', '中華民國115年8月16日'],
+        ['速別', '普通件'],
+      ]}
+    />
+  </div>
+);
+`;
+
+const VIA_PAIRS_DIV = { line: 4, column: 6 };
+
+describe('text that arrives as children', () => {
+  it('offers the attribute, the literal and the children as three runs', () => {
+    const info = readTextAt(
+      VIA_CHILDREN,
+      VIA_CHILDREN_DIV,
+      '主旨：本府訂於115年10月14日辦理研習營。',
+    );
+    expect(info?.editable).toBe(true);
+    expect(info?.parts).toEqual([
+      { kind: 'text', index: 0, value: '主旨' },
+      { kind: 'text', index: 1, value: '：' },
+      { kind: 'text', index: 2, value: '本府訂於115年10月14日辦理研習營。' },
+    ]);
+  });
+
+  it('writes between the tags of the call site that is on screen', () => {
+    const out = replaceTextAt(VIA_CHILDREN, VIA_CHILDREN_DIV, '依規定辦理。', {
+      index: 2,
+      expected: '依本府115年度數位人才培育計畫辦理。',
+      shown: '說明：依本府115年度數位人才培育計畫辦理。',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain('<Section name="說明">依規定辦理。</Section>');
+    expect(out.source).toContain('本府訂於115年10月14日辦理研習營。');
+  });
+
+  it('still writes the attribute half through the same element', () => {
+    const out = replaceTextAt(VIA_CHILDREN, VIA_CHILDREN_DIV, '辦法', {
+      index: 0,
+      expected: '主旨',
+      shown: '主旨：本府訂於115年10月14日辦理研習營。',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain('<Section name="辦法">');
+  });
+});
+
+describe('text that comes from a mapped array', () => {
+  it('resolves one element of the array by what is on screen', () => {
+    const info = readTextAt(VIA_MAP, VIA_MAP_DIV, '承辦人：陳小華');
+    expect(info?.editable).toBe(true);
+    expect(info?.parts).toEqual([{ kind: 'text', index: 0, value: '承辦人：陳小華' }]);
+  });
+
+  it('writes that entry and leaves its neighbours alone', () => {
+    const out = replaceTextAt(VIA_MAP, VIA_MAP_DIV, '承辦人：王大明', {
+      index: 0,
+      expected: '承辦人：陳小華',
+      shown: '承辦人：陳小華',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain("'承辦人：王大明'");
+    expect(out.source).toContain("'地址：000範例市範例路1號'");
+  });
+
+  it('escapes a quote that would end the string literal', () => {
+    const out = replaceTextAt(VIA_MAP, VIA_MAP_DIV, "it's here", {
+      index: 0,
+      shown: '承辦人：陳小華',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain("'it\\'s here'");
+  });
+
+  it('refuses when nothing on screen says which entry was clicked', () => {
+    expect(readTextAt(VIA_MAP, VIA_MAP_DIV)?.editable).toBe(false);
+  });
+
+  it('destructures a pair into its own runs', () => {
+    const info = readTextAt(VIA_PAIRS, VIA_PAIRS_DIV, '發文日期：中華民國115年8月16日');
+    expect(info?.parts).toEqual([
+      { kind: 'text', index: 0, value: '發文日期' },
+      { kind: 'text', index: 1, value: '：' },
+      { kind: 'text', index: 2, value: '中華民國115年8月16日' },
+    ]);
+  });
+
+  it('writes the half of the pair that was edited', () => {
+    const out = replaceTextAt(VIA_PAIRS, VIA_PAIRS_DIV, '中華民國115年9月1日', {
+      index: 2,
+      expected: '中華民國115年8月16日',
+      shown: '發文日期：中華民國115年8月16日',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain("['發文日期', '中華民國115年9月1日']");
+    expect(out.source).toContain("['速別', '普通件']");
+  });
+});
+
+// A code block: the words are a template literal handed to a helper as
+// children, so neither the element nor an attribute holds them.
+const VIA_TEMPLATE = [
+  'const Code = ({ children }: { children: ReactNode }) => (',
+  '  <pre style={mono}>{children}</pre>',
+  ');',
+  '',
+  'const Page = () => (',
+  '  <div>',
+  '    <Code>{`docs/',
+  '  my-report/',
+  '    index.tsx`}</Code>',
+  '  </div>',
+  ');',
+  '',
+].join('\n');
+
+const VIA_TEMPLATE_PRE = { line: 2, column: 2 };
+
+describe('text that is a template literal', () => {
+  it('offers a code block as one editable run', () => {
+    const info = readTextAt(VIA_TEMPLATE, VIA_TEMPLATE_PRE, 'docs/ my-report/ index.tsx');
+    expect(info?.editable).toBe(true);
+    expect(info?.parts).toEqual([
+      { kind: 'text', index: 0, value: 'docs/\n  my-report/\n    index.tsx' },
+    ]);
+  });
+
+  it('keeps the newlines and escapes what would end the literal', () => {
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal ${ is the point
+    const typed = 'docs/\n  a-`b`-${c}';
+    const out = replaceTextAt(VIA_TEMPLATE, VIA_TEMPLATE_PRE, typed, {
+      index: 0,
+      shown: 'docs/ my-report/ index.tsx',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    // A backslash, a backtick and a substitution would each end or reopen the
+    // literal; all three come back escaped.
+    expect(out.source).toContain('{`docs/\n  a-');
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: checking the escape, not a template
+    expect(out.source).toContain('a-\\`b\\`-\\${c}`}');
+  });
+});
+
 describe('readTextAt', () => {
   it('reports a single text child as one editable run', () => {
     const info = readTextAt(SOURCE, H1);

--- a/packages/core/src/editing/edit-ops.test.ts
+++ b/packages/core/src/editing/edit-ops.test.ts
@@ -36,6 +36,77 @@ const FIRST_TD = { line: 3, column: 4 };
 const SECOND_TD = { line: 3, column: 29 };
 const MIXED_P = { line: 4, column: 4 };
 
+// The shape that sends every government letter through a helper: the heading
+// holds no literal text at all, only the props its call site passes.
+const VIA_PROPS = `const Letterhead = ({ agency, kind }: { agency: string; kind: string }) => (
+  <h1 style={title}>
+    {agency}　{kind}
+  </h1>
+);
+
+const Page = () => (
+  <div>
+    <Letterhead agency="範例市政府" kind="函" />
+  </div>
+);
+`;
+
+const VIA_PROPS_H1 = { line: 2, column: 2 };
+
+const TWO_CALLS = `const Head = ({ name }: { name: string }) => <h2>{name}</h2>;
+
+const Page = () => (
+  <div>
+    <Head name="第一份" />
+    <Head name="第二份" />
+  </div>
+);
+`;
+
+const TWO_CALLS_H2 = { line: 1, column: 45 };
+
+describe('text that comes from props', () => {
+  it('follows the prop back to the call site and offers it', () => {
+    const info = readTextAt(VIA_PROPS, VIA_PROPS_H1, '範例市政府　函');
+    expect(info?.editable).toBe(true);
+    expect(info?.parts).toEqual([
+      { kind: 'text', index: 0, value: '範例市政府' },
+      { kind: 'text', index: 1, value: '函' },
+    ]);
+  });
+
+  it('writes the edit to the call site, leaving the expression alone', () => {
+    const out = replaceTextAt(VIA_PROPS, VIA_PROPS_H1, '新北市政府', {
+      index: 0,
+      expected: '範例市政府',
+      shown: '範例市政府　函',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain('agency="新北市政府"');
+    expect(out.source).toContain('{agency}　{kind}');
+  });
+
+  // Two call sites render the same component with different words. Without the
+  // rendered text to tell them apart, a save would rewrite whichever came first.
+  it('picks the call site whose words are the ones on screen', () => {
+    const out = replaceTextAt(TWO_CALLS, TWO_CALLS_H2, '改過的', {
+      index: 0,
+      expected: '第二份',
+      shown: '第二份',
+    });
+    expect(out.ok).toBe(true);
+    if (!out.ok) return;
+    expect(out.source).toContain('name="第一份"');
+    expect(out.source).toContain('name="改過的"');
+  });
+
+  it('refuses when the rendered text cannot say which call site is meant', () => {
+    const info = readTextAt(TWO_CALLS, TWO_CALLS_H2);
+    expect(info?.editable).toBe(false);
+  });
+});
+
 describe('readTextAt', () => {
   it('reports a single text child as one editable run', () => {
     const info = readTextAt(SOURCE, H1);

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -1,15 +1,17 @@
-import { type AstNode, findJsxAt, findJsxOnLine, parseSource, walkJsx } from './babel-walk.ts';
+import {
+  type AstNode,
+  findJsxAt,
+  findJsxOnLine,
+  parseSource,
+  walkAst,
+  walkJsx,
+} from './babel-walk.ts';
 
 export type EditTarget = { line: number; column: number };
 
 export type EditResult =
   | { ok: true; source: string }
   | { ok: false; status: number; error: string };
-
-/** JSX text is written literally; only these characters have to be escaped. */
-function escapeAttribute(text: string): string {
-  return text.replace(/"/g, '&quot;');
-}
 
 function escapeJsxText(text: string): string {
   return text.replace(/[{}<>]/g, (char) => `{'${char}'}`);
@@ -29,6 +31,18 @@ export type TextPart =
   | { kind: 'text'; index: number; value: string }
   | { kind: 'markup'; label: string };
 
+export type TextTargetInfo = {
+  editable: boolean;
+  /** The element's own text, markup excluded. */
+  text: string;
+  parts: TextPart[];
+  reason?: string;
+};
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+}
+
 function jsxChildren(element: AstNode): AstNode[] {
   return (element.children ?? []) as AstNode[];
 }
@@ -44,61 +58,116 @@ function labelOf(node: AstNode): string {
   return '…';
 }
 
-/** Text children with content, in document order. */
-function textNodes(element: AstNode): AstNode[] {
-  return jsxChildren(element).filter(
-    (child) => child.type === 'JSXText' && (child.value as string).trim() !== '',
-  );
+/*
+ * ---------------------------------------------------------------------------
+ * Where the words live
+ * ---------------------------------------------------------------------------
+ *
+ * The text on screen is often nowhere near the element that renders it. A
+ * government letter is written almost entirely through helpers:
+ *
+ *   {agency}　{kind}          ← an attribute at the call site
+ *   {label}：{value}          ← one entry of an array the call site passed
+ *   {name}：{children}        ← whatever sits between the call site's tags
+ *
+ * Each child of the element resolves on its own. Resolving the element as a
+ * whole is what used to make `{label}：{value}` offer nothing but the colon:
+ * the literal text was found, so the props were never looked for.
+ */
+
+/** A span of source an edit may rewrite, and the escaping that span needs. */
+type Slot = { value: string; start: number; end: number; escape: (text: string) => string };
+
+type Context = { ast: AstNode; source: string; shown?: string };
+
+/** Text written straight into the JSX. Its surrounding whitespace is indentation, so the slot excludes it. */
+function literalSlot(node: AstNode): Slot {
+  const raw = node.value as string;
+  const leading = (raw.match(/^\s*/)?.[0] ?? '').length;
+  const trailing = (raw.match(/\s*$/)?.[0] ?? '').length;
+  return {
+    value: raw.trim(),
+    start: node.start + leading,
+    end: node.end - trailing,
+    escape: escapeJsxText,
+  };
 }
 
-export function partsOf(element: AstNode): TextPart[] {
-  const parts: TextPart[] = [];
-  let index = 0;
-  for (const child of jsxChildren(element)) {
-    if (child.type === 'JSXText') {
-      const value = child.value as string;
-      if (value.trim() === '') continue;
-      parts.push({ kind: 'text', index: index++, value: value.trim() });
-      continue;
-    }
-    parts.push({ kind: 'markup', label: labelOf(child) });
-  }
-  return parts;
+/** `name="…"` at a call site. Only the quote in use has to be escaped. */
+function attributeSlot(node: AstNode, source: string): Slot {
+  const quote = source[node.start] ?? '"';
+  const entity = quote === '"' ? '&quot;' : '&apos;';
+  return {
+    value: node.value as string,
+    start: node.start + 1,
+    end: node.end - 1,
+    escape: (text) => text.split(quote).join(entity),
+  };
 }
 
-export type TextTargetInfo = {
-  editable: boolean;
-  /** The element's own text, markup excluded. */
-  text: string;
-  parts: TextPart[];
-  reason?: string;
-};
+/** A plain string in an array or object literal — a JS string, not JSX. */
+function stringSlot(node: AstNode, source: string): Slot {
+  const quote = source[node.start] ?? "'";
+  return {
+    value: node.value as string,
+    start: node.start + 1,
+    end: node.end - 1,
+    escape: (text) => text.split('\\').join('\\\\').split(quote).join(`\\${quote}`),
+  };
+}
 
-type PropRun = { name: string; value: string; start: number; end: number };
+/**
+ * A code block is written `<Code>{`docs/…`}</Code>` — the words are a template
+ * literal, not JSX text. Nothing has to be traced to reach them, so they are a
+ * slot wherever they appear: as a child of the element, or as the children one
+ * call site handed a helper.
+ */
+function expressionSlot(child: AstNode, source: string): Slot | null {
+  if (child.type !== 'JSXExpressionContainer') return null;
+  const expression = child.expression as AstNode | undefined;
+  if (expression?.type === 'StringLiteral') return stringSlot(expression, source);
+  if (expression?.type !== 'TemplateLiteral') return null;
+  // A substitution means part of the text is computed; writing over the whole
+  // literal would delete it.
+  if (((expression.expressions ?? []) as AstNode[]).length > 0) return null;
+  const quasis = (expression.quasis ?? []) as AstNode[];
+  const raw = ((quasis[0]?.value as { raw?: string } | undefined)?.raw ?? '') as string;
+  if (quasis.length !== 1) return null;
+  return {
+    value: raw,
+    start: expression.start + 1,
+    end: expression.end - 1,
+    escape: (text) => text.split('\\').join('\\\\').split('`').join('\\`').split('${').join('\\${'),
+  };
+}
 
-function componentOwning(ast: AstNode, element: AstNode): AstNode | null {
-  let found: AstNode | null = null;
-  const visit = (node: AstNode, declarator: AstNode | null): void => {
+function identifierName(child: AstNode): string | null {
+  if (child.type !== 'JSXExpressionContainer') return null;
+  const expression = child.expression as AstNode | undefined;
+  if (expression?.type !== 'Identifier') return null;
+  return (expression.name as string) ?? null;
+}
+
+/** The chain of nodes from the program down to this element — its scopes, in order. */
+function pathTo(ast: AstNode, element: AstNode): AstNode[] | null {
+  let found: AstNode[] | null = null;
+  const visit = (node: AstNode, trail: AstNode[]): void => {
     if (found) return;
+    const here = [...trail, node];
     if (node === element) {
-      found = declarator;
+      found = here;
       return;
     }
-    const next = node.type === 'VariableDeclarator' ? node : declarator;
     for (const key of Object.keys(node)) {
       if (key === 'loc') continue;
       const value = node[key];
       if (Array.isArray(value)) {
-        for (const child of value) if (isAstNode(child)) visit(child, next);
-      } else if (isAstNode(value)) visit(value, next);
+        for (const child of value) if (isAstNode(child)) visit(child, here);
+      } else if (isAstNode(value)) visit(value, here);
     }
   };
-  visit(ast, null);
+  visit(ast, []);
   return found;
-}
-
-function isAstNode(value: unknown): value is AstNode {
-  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
 }
 
 function propNames(declarator: AstNode): string[] {
@@ -110,84 +179,278 @@ function propNames(declarator: AstNode): string[] {
     .filter((name) => name !== '');
 }
 
-function expressionNames(element: AstNode): string[] | null {
-  const names: string[] = [];
-  for (const child of jsxChildren(element)) {
-    if (child.type === 'JSXText') {
-      if ((child.value as string).trim() !== '') return null;
-      continue;
-    }
-    if (child.type !== 'JSXExpressionContainer') return null;
-    const name = ((child.expression as AstNode | undefined)?.name as string | undefined) ?? '';
-    if (name === '') return null;
-    names.push(name);
+/** The component this element belongs to, and the props it declares. */
+function componentScope(path: AstNode[]): { name: string; props: string[] } | null {
+  for (let index = path.length - 1; index >= 0; index--) {
+    const node = path[index];
+    if (node?.type !== 'VariableDeclarator') continue;
+    const name = (node.id as AstNode | undefined)?.name as string | undefined;
+    const props = propNames(node);
+    if (name !== undefined && props.length > 0) return { name, props };
   }
-  return names.length > 0 ? names : null;
+  return null;
 }
 
-function callSiteRuns(node: AstNode, wanted: string[]): PropRun[] | null {
+/** The `xs.map(entry => …)` this element is rendered inside, if any. */
+function mapScope(path: AstNode[]): { pattern: AstNode; array: string } | null {
+  for (let index = path.length - 1; index >= 1; index--) {
+    const arrow = path[index];
+    const call = path[index - 1];
+    if (arrow?.type !== 'ArrowFunctionExpression' || call?.type !== 'CallExpression') continue;
+    const callee = call.callee as AstNode | undefined;
+    if (callee?.type !== 'MemberExpression') continue;
+    if (((callee.property as AstNode | undefined)?.name as string | undefined) !== 'map') continue;
+    const object = callee.object as AstNode | undefined;
+    const pattern = ((arrow.params ?? []) as AstNode[])[0];
+    if (object?.type !== 'Identifier' || !pattern) continue;
+    return { pattern, array: object.name as string };
+  }
+  return null;
+}
+
+function patternNames(pattern: AstNode): string[] {
+  if (pattern.type === 'Identifier') return [pattern.name as string];
+  if (pattern.type === 'ArrayPattern') {
+    return ((pattern.elements ?? []) as (AstNode | null)[])
+      .filter((element): element is AstNode => element?.type === 'Identifier')
+      .map((element) => element.name as string);
+  }
+  if (pattern.type === 'ObjectPattern') {
+    return ((pattern.properties ?? []) as AstNode[])
+      .map(
+        (property) => ((property.value as AstNode | undefined)?.name as string | undefined) ?? '',
+      )
+      .filter((name) => name !== '');
+  }
+  return [];
+}
+
+/** Destructure one array entry the way the map callback does. */
+function entryBindings(pattern: AstNode, entry: AstNode, source: string): Map<string, Slot> | null {
+  if (pattern.type === 'Identifier') {
+    if (entry.type !== 'StringLiteral') return null;
+    return new Map([[pattern.name as string, stringSlot(entry, source)]]);
+  }
+
+  const bindings = new Map<string, Slot>();
+  if (pattern.type === 'ArrayPattern') {
+    if (entry.type !== 'ArrayExpression') return null;
+    const values = (entry.elements ?? []) as (AstNode | null)[];
+    const targets = (pattern.elements ?? []) as (AstNode | null)[];
+    for (let index = 0; index < targets.length; index++) {
+      const target = targets[index];
+      if (!target) continue;
+      const value = values[index];
+      if (target.type !== 'Identifier' || value?.type !== 'StringLiteral') return null;
+      bindings.set(target.name as string, stringSlot(value, source));
+    }
+    return bindings.size > 0 ? bindings : null;
+  }
+
+  if (pattern.type === 'ObjectPattern') {
+    if (entry.type !== 'ObjectExpression') return null;
+    for (const property of (pattern.properties ?? []) as AstNode[]) {
+      const key = ((property.key as AstNode | undefined)?.name as string | undefined) ?? '';
+      const local = ((property.value as AstNode | undefined)?.name as string | undefined) ?? '';
+      if (key === '' || local === '') return null;
+      const match = ((entry.properties ?? []) as AstNode[]).find(
+        (candidate) =>
+          ((candidate.key as AstNode | undefined)?.name as string | undefined) === key ||
+          ((candidate.key as AstNode | undefined)?.value as string | undefined) === key,
+      );
+      const value = match?.value as AstNode | undefined;
+      if (value?.type !== 'StringLiteral') return null;
+      bindings.set(local, stringSlot(value, source));
+    }
+    return bindings.size > 0 ? bindings : null;
+  }
+
+  return null;
+}
+
+/**
+ * Two call sites of the same component render different words, and only what
+ * is on screen can say which one was clicked — without it a save rewrites
+ * whichever came first in the file. An entry that cannot be told apart from
+ * its neighbours is therefore not editable at all.
+ */
+function fits(bindings: Map<string, Slot>, shown?: string): boolean {
+  if (shown === undefined) return true;
+  const visible = normalizeText(shown);
+  const values = [...bindings.values()].map((slot) => normalizeText(slot.value));
+  if (values.join('') === '') return false;
+  return values.every((value) => visible.includes(value));
+}
+
+function tagName(node: AstNode): string | undefined {
+  return ((node.openingElement as AstNode | undefined)?.name as AstNode | undefined)?.name as
+    | string
+    | undefined;
+}
+
+/**
+ * `<Section name="主旨">…</Section>` puts its words between the tags rather
+ * than in an attribute. Only a lone run of text qualifies: anything nested
+ * would be flattened into a string and lost on the first save.
+ */
+function childrenSlot(node: AstNode, source: string): Slot | null {
+  const children = jsxChildren(node).filter(
+    (child) => child.type !== 'JSXText' || (child.value as string).trim() !== '',
+  );
+  const only = children[0];
+  if (children.length !== 1 || !only) return null;
+  if (only.type === 'JSXText') return literalSlot(only);
+  return expressionSlot(only, source);
+}
+
+function callSiteBindings(
+  node: AstNode,
+  wanted: string[],
+  source: string,
+): Map<string, Slot> | null {
   const attributes = ((node.openingElement as AstNode | undefined)?.attributes ?? []) as AstNode[];
-  const runs: PropRun[] = [];
+  const bindings = new Map<string, Slot>();
   for (const name of wanted) {
+    if (name === 'children') {
+      const slot = childrenSlot(node, source);
+      if (!slot) return null;
+      bindings.set(name, slot);
+      continue;
+    }
     const attribute = attributes.find(
       (candidate) => ((candidate.name as AstNode | undefined)?.name as string | undefined) === name,
     );
     const value = attribute?.value as AstNode | undefined;
     if (value?.type !== 'StringLiteral') return null;
-    runs.push({ name, value: value.value as string, start: value.start + 1, end: value.end - 1 });
+    bindings.set(name, attributeSlot(value, source));
   }
-  return runs;
+  return bindings;
 }
 
-/**
- * The words behind `{agency}` live at the call site, not in the element the
- * click landed on. Writing them into the element would replace the expression
- * with one caller's text, so the runs an edit may touch are the attributes.
- *
- * Two call sites of the same component render different words, and only what
- * is on screen can say which one was clicked — without it, a save rewrites
- * whichever came first in the file.
- */
-function propRuns(ast: AstNode, element: AstNode, shown?: string): PropRun[] | null {
-  const names = expressionNames(element);
-  if (!names) return null;
-  const owner = componentOwning(ast, element);
-  const component = (owner?.id as AstNode | undefined)?.name as string | undefined;
-  if (!owner || !component) return null;
-  const declared = propNames(owner);
-  if (!names.every((name) => declared.includes(name))) return null;
-
-  const matches: PropRun[][] = [];
-  walkJsx(ast, (node) => {
-    const tag = ((node.openingElement as AstNode | undefined)?.name as AstNode | undefined)?.name as
-      | string
-      | undefined;
-    if (tag !== component) return;
-    const runs = callSiteRuns(node, names);
-    if (!runs) return;
-    if (shown !== undefined) {
-      const visible = normalizeText(shown);
-      if (!runs.every((run) => visible.includes(normalizeText(run.value)))) return;
-    }
-    matches.push(runs);
+function propBindings(ctx: Context, component: string, wanted: string[]): Map<string, Slot> | null {
+  const matches: Map<string, Slot>[] = [];
+  walkJsx(ctx.ast, (node) => {
+    if (tagName(node) !== component) return;
+    const bindings = callSiteBindings(node, wanted, ctx.source);
+    if (bindings && fits(bindings, ctx.shown)) matches.push(bindings);
   });
   return matches.length === 1 ? (matches[0] ?? null) : null;
 }
 
-function describe(element: AstNode, ast?: AstNode, shown?: string): TextTargetInfo {
-  const parts = partsOf(element);
+/** Every array literal that could be the one being mapped over. */
+function arrayCandidates(ctx: Context, name: string, component: string | null): AstNode[] {
+  const found: AstNode[] = [];
+  walkAst(ctx.ast, (node) => {
+    if (node.type === 'VariableDeclarator') {
+      const id = node.id as AstNode | undefined;
+      const init = node.init as AstNode | undefined;
+      if (id?.type === 'Identifier' && id.name === name && init?.type === 'ArrayExpression') {
+        found.push(init);
+      }
+      return;
+    }
+    if (node.type !== 'JSXElement' || component === null || tagName(node) !== component) return;
+    const attributes = ((node.openingElement as AstNode).attributes ?? []) as AstNode[];
+    for (const attribute of attributes) {
+      if (((attribute.name as AstNode | undefined)?.name as string | undefined) !== name) continue;
+      const value = attribute.value as AstNode | undefined;
+      if (value?.type !== 'JSXExpressionContainer') continue;
+      const expression = value.expression as AstNode | undefined;
+      if (expression?.type === 'ArrayExpression') found.push(expression);
+    }
+  });
+  return found;
+}
+
+function mapBindings(
+  ctx: Context,
+  scope: { pattern: AstNode; array: string },
+  component: string | null,
+  wanted: string[],
+): Map<string, Slot> | null {
+  const matches: Map<string, Slot>[] = [];
+  for (const array of arrayCandidates(ctx, scope.array, component)) {
+    for (const entry of (array.elements ?? []) as (AstNode | null)[]) {
+      if (!entry) continue;
+      const bindings = entryBindings(scope.pattern, entry, ctx.source);
+      if (!bindings || !wanted.every((name) => bindings.has(name))) continue;
+      if (fits(bindings, ctx.shown)) matches.push(bindings);
+    }
+  }
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+}
+
+function bindingsFor(ctx: Context, element: AstNode, names: string[]): Map<string, Slot> | null {
+  const path = pathTo(ctx.ast, element);
+  if (!path) return null;
+  const map = mapScope(path);
+  const component = componentScope(path);
+  const mapped = map ? patternNames(map.pattern) : [];
+
+  const bindings = new Map<string, Slot>();
+  const fromMap = names.filter((name) => mapped.includes(name));
+  if (map && fromMap.length > 0) {
+    const entry = mapBindings(ctx, map, component?.name ?? null, fromMap);
+    if (entry)
+      for (const name of fromMap) {
+        const slot = entry.get(name);
+        if (slot) bindings.set(name, slot);
+      }
+  }
+
+  const fromProps = names.filter(
+    (name) => !mapped.includes(name) && (component?.props.includes(name) ?? false),
+  );
+  if (component && fromProps.length > 0) {
+    const call = propBindings(ctx, component.name, fromProps);
+    if (call) for (const [name, slot] of call) bindings.set(name, slot);
+  }
+
+  return bindings.size > 0 ? bindings : null;
+}
+
+type Resolution = { parts: TextPart[]; slots: Slot[] };
+
+/** The element's children, each resolved to a writable slot or left as markup. */
+function resolve(element: AstNode, ctx?: Context): Resolution {
+  const children = jsxChildren(element);
+  const names = children
+    .map((child) => identifierName(child))
+    .filter((name): name is string => name !== null);
+  const bindings = ctx && names.length > 0 ? bindingsFor(ctx, element, names) : null;
+
+  const parts: TextPart[] = [];
+  const slots: Slot[] = [];
+  const take = (slot: Slot): void => {
+    parts.push({ kind: 'text', index: slots.length, value: slot.value });
+    slots.push(slot);
+  };
+
+  for (const child of children) {
+    if (child.type === 'JSXText') {
+      if ((child.value as string).trim() !== '') take(literalSlot(child));
+      continue;
+    }
+    const name = identifierName(child);
+    const slot =
+      (name === null ? undefined : bindings?.get(name)) ??
+      (ctx ? (expressionSlot(child, ctx.source) ?? undefined) : undefined);
+    if (slot) take(slot);
+    else parts.push({ kind: 'markup', label: labelOf(child) });
+  }
+  return { parts, slots };
+}
+
+export function partsOf(element: AstNode): TextPart[] {
+  return resolve(element).parts;
+}
+
+function describe(element: AstNode, ctx?: Context): TextTargetInfo {
+  const { parts } = resolve(element, ctx);
   const texts = parts.filter(
     (part): part is Extract<TextPart, { kind: 'text' }> => part.kind === 'text',
   );
   if (texts.length === 0) {
-    const runs = ast ? propRuns(ast, element, shown) : null;
-    if (runs) {
-      return {
-        editable: true,
-        text: runs.map((run) => run.value).join(' '),
-        parts: runs.map((run, index) => ({ kind: 'text', index, value: run.value })),
-      };
-    }
     const generated = parts.some((part) => part.kind === 'markup' && part.label === '{…}');
     return {
       editable: false,
@@ -210,7 +473,7 @@ export function readTextAt(
   const ast = parseSource(source);
   if (!ast) return null;
   const element = findJsxAt(ast, target.line, target.column);
-  return element ? describe(element, ast, shown) : null;
+  return element ? describe(element, { ast, source, shown }) : null;
 }
 
 export type ResolvedTarget = TextTargetInfo & EditTarget;
@@ -230,6 +493,7 @@ export function resolveTextTarget(
 ): ResolvedTarget | null {
   const ast = parseSource(source);
   if (!ast) return null;
+  const ctx: Context = { ast, source, shown: expected };
   const shown = expected ? normalizeText(expected) : null;
 
   // Compare run by run. Joining them would introduce spacing the DOM never
@@ -244,14 +508,14 @@ export function resolveTextTarget(
   for (const candidate of candidates) {
     const exact = findJsxAt(ast, candidate.line, candidate.column);
     if (exact) {
-      const info = describe(exact, ast, expected);
+      const info = describe(exact, ctx);
       if (info.editable && matches(info)) return { ...info, ...candidate };
     }
     // The column may have drifted; scan the rest of the line, but only accept
     // an element whose text is actually on screen.
     if (!shown) continue;
     for (const node of findJsxOnLine(ast, candidate.line, candidate.column)) {
-      const info = describe(node, ast, expected);
+      const info = describe(node, ctx);
       const start = node.loc?.start;
       if (!info.editable || !matches(info) || !start) continue;
       return { ...info, line: start.line, column: start.column };
@@ -261,7 +525,7 @@ export function resolveTextTarget(
   const first = candidates[0];
   if (!first) return null;
   const clicked = findJsxAt(ast, first.line, first.column);
-  return clicked ? { ...describe(clicked), ...first } : null;
+  return clicked ? { ...describe(clicked, ctx), ...first } : null;
 }
 
 /**
@@ -281,43 +545,18 @@ export function replaceTextAt(
   const element = findJsxAt(ast, target.line, target.column);
   if (!element) return { ok: false, status: 404, error: 'no element at that source location' };
 
-  const runs = textNodes(element).length === 0 ? propRuns(ast, element, opts.shown) : null;
-  if (runs) {
-    const run = runs[opts.index ?? 0];
-    if (!run) return { ok: false, status: 404, error: 'no such text run in this element' };
-    if (opts.expected !== undefined && normalizeText(run.value) !== normalizeText(opts.expected)) {
-      return {
-        ok: false,
-        status: 409,
-        error: 'source changed since this was opened — reselect it',
-      };
-    }
-    return {
-      ok: true,
-      source: source.slice(0, run.start) + escapeAttribute(text) + source.slice(run.end),
-    };
-  }
-
-  const nodes = textNodes(element);
-  if (nodes.length === 0) {
+  const { slots } = resolve(element, { ast, source, shown: opts.shown });
+  if (slots.length === 0) {
     return { ok: false, status: 422, error: 'element has no text to replace' };
   }
-  const child = nodes[opts.index ?? 0];
-  if (!child) return { ok: false, status: 404, error: 'no such text run in this element' };
-
-  const raw = child.value as string;
-  if (opts.expected !== undefined && normalizeText(raw) !== normalizeText(opts.expected)) {
+  const slot = slots[opts.index ?? 0];
+  if (!slot) return { ok: false, status: 404, error: 'no such text run in this element' };
+  if (opts.expected !== undefined && normalizeText(slot.value) !== normalizeText(opts.expected)) {
     return { ok: false, status: 409, error: 'source changed since this was opened — reselect it' };
   }
 
-  const leading = raw.match(/^\s*/)?.[0] ?? '';
-  const trailing = raw.match(/\s*$/)?.[0] ?? '';
-  const next =
-    source.slice(0, child.start) +
-    leading +
-    escapeJsxText(text) +
-    trailing +
-    source.slice(child.end);
-
-  return { ok: true, source: next };
+  return {
+    ok: true,
+    source: source.slice(0, slot.start) + slot.escape(text) + source.slice(slot.end),
+  };
 }

--- a/packages/core/src/editing/edit-ops.ts
+++ b/packages/core/src/editing/edit-ops.ts
@@ -1,4 +1,4 @@
-import { type AstNode, findJsxAt, findJsxOnLine, parseSource } from './babel-walk.ts';
+import { type AstNode, findJsxAt, findJsxOnLine, parseSource, walkJsx } from './babel-walk.ts';
 
 export type EditTarget = { line: number; column: number };
 
@@ -7,6 +7,10 @@ export type EditResult =
   | { ok: false; status: number; error: string };
 
 /** JSX text is written literally; only these characters have to be escaped. */
+function escapeAttribute(text: string): string {
+  return text.replace(/"/g, '&quot;');
+}
+
 function escapeJsxText(text: string): string {
   return text.replace(/[{}<>]/g, (char) => `{'${char}'}`);
 }
@@ -70,12 +74,120 @@ export type TextTargetInfo = {
   reason?: string;
 };
 
-function describe(element: AstNode): TextTargetInfo {
+type PropRun = { name: string; value: string; start: number; end: number };
+
+function componentOwning(ast: AstNode, element: AstNode): AstNode | null {
+  let found: AstNode | null = null;
+  const visit = (node: AstNode, declarator: AstNode | null): void => {
+    if (found) return;
+    if (node === element) {
+      found = declarator;
+      return;
+    }
+    const next = node.type === 'VariableDeclarator' ? node : declarator;
+    for (const key of Object.keys(node)) {
+      if (key === 'loc') continue;
+      const value = node[key];
+      if (Array.isArray(value)) {
+        for (const child of value) if (isAstNode(child)) visit(child, next);
+      } else if (isAstNode(value)) visit(value, next);
+    }
+  };
+  visit(ast, null);
+  return found;
+}
+
+function isAstNode(value: unknown): value is AstNode {
+  return typeof value === 'object' && value !== null && typeof (value as AstNode).type === 'string';
+}
+
+function propNames(declarator: AstNode): string[] {
+  const params = (declarator.init as AstNode | undefined)?.params as AstNode[] | undefined;
+  const pattern = params?.[0];
+  if (pattern?.type !== 'ObjectPattern') return [];
+  return ((pattern.properties ?? []) as AstNode[])
+    .map((property) => ((property.key as AstNode | undefined)?.name as string | undefined) ?? '')
+    .filter((name) => name !== '');
+}
+
+function expressionNames(element: AstNode): string[] | null {
+  const names: string[] = [];
+  for (const child of jsxChildren(element)) {
+    if (child.type === 'JSXText') {
+      if ((child.value as string).trim() !== '') return null;
+      continue;
+    }
+    if (child.type !== 'JSXExpressionContainer') return null;
+    const name = ((child.expression as AstNode | undefined)?.name as string | undefined) ?? '';
+    if (name === '') return null;
+    names.push(name);
+  }
+  return names.length > 0 ? names : null;
+}
+
+function callSiteRuns(node: AstNode, wanted: string[]): PropRun[] | null {
+  const attributes = ((node.openingElement as AstNode | undefined)?.attributes ?? []) as AstNode[];
+  const runs: PropRun[] = [];
+  for (const name of wanted) {
+    const attribute = attributes.find(
+      (candidate) => ((candidate.name as AstNode | undefined)?.name as string | undefined) === name,
+    );
+    const value = attribute?.value as AstNode | undefined;
+    if (value?.type !== 'StringLiteral') return null;
+    runs.push({ name, value: value.value as string, start: value.start + 1, end: value.end - 1 });
+  }
+  return runs;
+}
+
+/**
+ * The words behind `{agency}` live at the call site, not in the element the
+ * click landed on. Writing them into the element would replace the expression
+ * with one caller's text, so the runs an edit may touch are the attributes.
+ *
+ * Two call sites of the same component render different words, and only what
+ * is on screen can say which one was clicked — without it, a save rewrites
+ * whichever came first in the file.
+ */
+function propRuns(ast: AstNode, element: AstNode, shown?: string): PropRun[] | null {
+  const names = expressionNames(element);
+  if (!names) return null;
+  const owner = componentOwning(ast, element);
+  const component = (owner?.id as AstNode | undefined)?.name as string | undefined;
+  if (!owner || !component) return null;
+  const declared = propNames(owner);
+  if (!names.every((name) => declared.includes(name))) return null;
+
+  const matches: PropRun[][] = [];
+  walkJsx(ast, (node) => {
+    const tag = ((node.openingElement as AstNode | undefined)?.name as AstNode | undefined)?.name as
+      | string
+      | undefined;
+    if (tag !== component) return;
+    const runs = callSiteRuns(node, names);
+    if (!runs) return;
+    if (shown !== undefined) {
+      const visible = normalizeText(shown);
+      if (!runs.every((run) => visible.includes(normalizeText(run.value)))) return;
+    }
+    matches.push(runs);
+  });
+  return matches.length === 1 ? (matches[0] ?? null) : null;
+}
+
+function describe(element: AstNode, ast?: AstNode, shown?: string): TextTargetInfo {
   const parts = partsOf(element);
   const texts = parts.filter(
     (part): part is Extract<TextPart, { kind: 'text' }> => part.kind === 'text',
   );
   if (texts.length === 0) {
+    const runs = ast ? propRuns(ast, element, shown) : null;
+    if (runs) {
+      return {
+        editable: true,
+        text: runs.map((run) => run.value).join(' '),
+        parts: runs.map((run, index) => ({ kind: 'text', index, value: run.value })),
+      };
+    }
     const generated = parts.some((part) => part.kind === 'markup' && part.label === '{…}');
     return {
       editable: false,
@@ -90,11 +202,15 @@ function describe(element: AstNode): TextTargetInfo {
 }
 
 /** What the inspector shows before the user starts typing. */
-export function readTextAt(source: string, target: EditTarget): TextTargetInfo | null {
+export function readTextAt(
+  source: string,
+  target: EditTarget,
+  shown?: string,
+): TextTargetInfo | null {
   const ast = parseSource(source);
   if (!ast) return null;
   const element = findJsxAt(ast, target.line, target.column);
-  return element ? describe(element) : null;
+  return element ? describe(element, ast, shown) : null;
 }
 
 export type ResolvedTarget = TextTargetInfo & EditTarget;
@@ -128,14 +244,14 @@ export function resolveTextTarget(
   for (const candidate of candidates) {
     const exact = findJsxAt(ast, candidate.line, candidate.column);
     if (exact) {
-      const info = describe(exact);
+      const info = describe(exact, ast, expected);
       if (info.editable && matches(info)) return { ...info, ...candidate };
     }
     // The column may have drifted; scan the rest of the line, but only accept
     // an element whose text is actually on screen.
     if (!shown) continue;
     for (const node of findJsxOnLine(ast, candidate.line, candidate.column)) {
-      const info = describe(node);
+      const info = describe(node, ast, expected);
       const start = node.loc?.start;
       if (!info.editable || !matches(info) || !start) continue;
       return { ...info, line: start.line, column: start.column };
@@ -157,13 +273,30 @@ export function replaceTextAt(
   source: string,
   target: EditTarget,
   text: string,
-  opts: { index?: number; expected?: string } = {},
+  opts: { index?: number; expected?: string; shown?: string } = {},
 ): EditResult {
   const ast = parseSource(source);
   if (!ast) return { ok: false, status: 422, error: 'could not parse document source' };
 
   const element = findJsxAt(ast, target.line, target.column);
   if (!element) return { ok: false, status: 404, error: 'no element at that source location' };
+
+  const runs = textNodes(element).length === 0 ? propRuns(ast, element, opts.shown) : null;
+  if (runs) {
+    const run = runs[opts.index ?? 0];
+    if (!run) return { ok: false, status: 404, error: 'no such text run in this element' };
+    if (opts.expected !== undefined && normalizeText(run.value) !== normalizeText(opts.expected)) {
+      return {
+        ok: false,
+        status: 409,
+        error: 'source changed since this was opened — reselect it',
+      };
+    }
+    return {
+      ok: true,
+      source: source.slice(0, run.start) + escapeAttribute(text) + source.slice(run.end),
+    };
+  }
 
   const nodes = textNodes(element);
   if (nodes.length === 0) {

--- a/packages/core/src/vite/routes/edit.ts
+++ b/packages/core/src/vite/routes/edit.ts
@@ -66,6 +66,7 @@ export function registerEditRoutes(server: ViteDevServer, ctx: ApiContext): void
         const result = replaceTextAt(source, loc, text, {
           index: typeof body.index === 'number' ? body.index : undefined,
           expected: typeof body.expected === 'string' ? body.expected : undefined,
+          shown: typeof body.shown === 'string' ? body.shown : undefined,
         });
         if (!result.ok) return json(res, result.status, { error: result.error });
         if (result.source !== source) await fs.writeFile(entry, result.source, 'utf8');


### PR DESCRIPTION
## What

The inspector could only edit text an element held literally. A document written through helpers — which is most real documents — reported `text is produced by code` for nearly all of itself.

Each child of the selected element now resolves on its own to a span of source an edit may rewrite:

| child | where the words live |
| --- | --- |
| `Executive summary` | the JSX text (unchanged) |
| `{agency}` | the call site's `agency="…"` |
| `{children}` | between the call site's tags |
| `{line}` | one entry of an array the call site passed |
| `{label}` / `{value}` | that entry, destructured |
| ``{`docs/…`}`` | a template literal |
| anything else | still markup, still refused |

Resolving the element as a whole was also why `{label}：{value}` offered nothing but the colon — the literal was found, so the props were never looked for.

Two call sites of the same component, or two entries of the same array, are told apart by what is on screen. Anything that cannot be resolved that way is refused rather than guessed, so a save never rewrites a sibling.

## Also

- A contents row selects the heading it was generated from, and scrolls to it. The list stays a view of the headings.
- The text panel is **one** field rather than one per run — a sentence broken by five `<code>` spans now reads like a sentence, with the markup as inert chips.

## Measured

On a real government letter (公文, helpers throughout): **3 → 34** editable lines. The four that remain are container `<div>`s whose rows are the editable things.

## Verified

- 195 unit tests pass (`edit-ops.test.ts` +11: children, string arrays, destructured pairs, template literals, quote/backtick/`${` escaping, and refusal when the on-screen text cannot identify the run).
- End-to-end in the browser, each writing to the right span and leaving neighbours alone: a mapped array entry, a `<Section>`'s children, a `<pre>` template literal, and a heading reached from the contents list.